### PR TITLE
feat/user 회원정보 조회/수정 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ hs_err_pid*
 .gradle/
 build/
 !gradle-wrapper.jar
+!SpringBoot/gradle/wrapper/gradle-wrapper.properties
 
 # IntelliJ IDEA
 .idea/
@@ -38,11 +39,7 @@ Temporary Items
 
 # Ignore contents of the etc/ignore folder
 etc/ignore/
-SpringBoot/src/main/resources/application-local.properties
-SpringBoot/src/main/resources/application-prod.properties
-SpringBoot/src/main/resources/application-local.yml
-SpringBoot/src/main/resources/application-prod.yml
-!SpringBoot/gradle/wrapper/gradle-wrapper.properties
-SpringBoot/log
-SpringBoot/boards-files
 Database/ignore
+SpringBoot/src/main/resources/*.properties
+SpringBoot/src/main/resources/*.yml
+SpringBoot/log

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/MyInfoController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/MyInfoController.java
@@ -1,0 +1,62 @@
+package com.seungwook.ktsp.domain.user.controller;
+
+import com.seungwook.ktsp.domain.user.dto.request.MyInfoUpdateRequest;
+import com.seungwook.ktsp.domain.user.dto.request.PasswordUpdateRequest;
+import com.seungwook.ktsp.domain.user.dto.response.MyInfoResponse;
+import com.seungwook.ktsp.domain.user.entity.User;
+import com.seungwook.ktsp.domain.user.mapper.UserResponseMapper;
+import com.seungwook.ktsp.domain.user.service.UserService;
+import com.seungwook.ktsp.global.auth.service.AuthService;
+import com.seungwook.ktsp.global.response.Response;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MyInfoController {
+
+    private final AuthService authService;
+    private final UserService userService;
+
+    // 내 정보 조회
+    @GetMapping("/service/user")
+    public ResponseEntity<Response<MyInfoResponse>> getMyInfo() {
+
+        User user = userService.getUserInformation(authService.getUser());
+        MyInfoResponse response = UserResponseMapper.toMyinfoResponse(user);
+
+        return ResponseEntity.ok(Response.<MyInfoResponse>builder()
+                .message("내 정보를 불러왔습니다.")
+                .data(response)
+                .build());
+    }
+
+    // 내 정보 수정
+    @PatchMapping("/service/user")
+    public ResponseEntity<Response<MyInfoResponse>> updateMyInfo(@Valid @RequestBody MyInfoUpdateRequest request) {
+
+        User user = userService.updateUserInformation(authService.getUser(), request);
+        MyInfoResponse response = UserResponseMapper.toMyinfoResponse(user);
+
+        return ResponseEntity.ok(Response.<MyInfoResponse>builder()
+                .message("내 정보를 수정했습니다.")
+                .data(response)
+                .build());
+    }
+
+    // 비밀번호 변경
+    @PatchMapping("/service/password")
+    public ResponseEntity<Response<Void>> updatePassword(@Valid @RequestBody PasswordUpdateRequest request) {
+
+        userService.updatePassword(authService.getUser(), request.getPassword());
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("비밀번호가 변경되었습니다.")
+                .build());
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/MyInfoController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/MyInfoController.java
@@ -27,7 +27,7 @@ public class MyInfoController {
     @GetMapping("/service/user")
     public ResponseEntity<Response<MyInfoResponse>> getMyInfo() {
 
-        User user = userService.getUserInformation(authService.getUser());
+        User user = userService.getUserInformation(authService.getUserId());
         MyInfoResponse response = UserResponseMapper.toMyinfoResponse(user);
 
         return ResponseEntity.ok(Response.<MyInfoResponse>builder()
@@ -40,7 +40,7 @@ public class MyInfoController {
     @PatchMapping("/service/user")
     public ResponseEntity<Response<MyInfoResponse>> updateMyInfo(@Valid @RequestBody MyInfoUpdateRequest request) {
 
-        User user = userService.updateUserInformation(authService.getUser(), request);
+        User user = userService.updateUserInformation(authService.getUserId(), request);
         MyInfoResponse response = UserResponseMapper.toMyinfoResponse(user);
 
         return ResponseEntity.ok(Response.<MyInfoResponse>builder()
@@ -53,7 +53,7 @@ public class MyInfoController {
     @PatchMapping("/service/password")
     public ResponseEntity<Response<Void>> updatePassword(@Valid @RequestBody PasswordUpdateRequest request) {
 
-        userService.updatePassword(authService.getUser(), request.getPassword());
+        userService.updatePassword(authService.getUserId(), request.getPassword());
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("비밀번호가 변경되었습니다.")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/MyInfoUpdateRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/MyInfoUpdateRequest.java
@@ -1,0 +1,48 @@
+package com.seungwook.ktsp.domain.user.dto.request;
+
+import com.seungwook.ktsp.domain.user.entity.enums.AcademicYear;
+import com.seungwook.ktsp.domain.user.entity.enums.Campus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class MyInfoUpdateRequest {
+
+    @Schema(description = "사용자 학년", example = "FIRST_YEAR, SECOND_YEAR, THIRD_YEAR, FOURTH_YEAR, GRADUATE")
+    @NotNull(message = "학년은 필수 항목입니다.")
+    private final AcademicYear academicYear;
+
+    @Schema(description = "사용자 전화번호", example = "010-1234-5678")
+    @NotBlank(message = "연락처 입력은 필수입니다.")
+    @Pattern(regexp = "^01[0-9]-\\d{4}-\\d{4}$", message = "연락처 형식이 잘못되었습니다.")
+    @Size(min = 13, max = 13, message = "연락처는 하이픈(-) 포함 13자 입니다.")
+    private final String phoneNumber;
+
+    @Schema(description = "사용자 전공", example = "AI소프트웨어")
+    @NotBlank(message = "전공은 필수 항목입니다.")
+    @Size(min = 2, max = 20, message = "전공은 최소 2자 ~ 최대 20자 입니다.")
+    private final String major;
+
+    // inclusive: 해당 값과 같아도 유효한지 여부
+    @NotNull
+    @Schema(description = "직전학기 학점", example = "3.66")
+    @DecimalMin(value = "0.0", inclusive = true, message = "학점은 최소 0.0 이상이어야 합니다.")
+    @DecimalMax(value = "4.5", inclusive = true, message = "학점은 최대 4.5 이하이어야 합니다.")
+    @Digits(integer = 1, fraction = 2, message = "학점은 소수점 둘째자리까지 입력 가능합니다.")
+    private final BigDecimal previousGpa;
+
+    @Schema(description = "캠퍼스", example = "CHUNCHEON, SAMCHEOK, DOGYE")
+    @NotNull(message = "캠퍼스는 필수 항목입니다.")
+    private final Campus campus;
+
+    public MyInfoUpdateRequest(AcademicYear academicYear, String phoneNumber, String major, BigDecimal previousGpa, Campus campus) {
+        this.academicYear = academicYear;
+        this.phoneNumber = phoneNumber;
+        this.major = major;
+        this.previousGpa = previousGpa;
+        this.campus = campus;
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/PasswordUpdateRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/PasswordUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.seungwook.ktsp.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class PasswordUpdateRequest {
+
+    @Schema(description = "사용자 비밀번호", example = "SecurePass123!")
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 ~ 최대 30자 입니다.")
+    private final String password;
+
+    public PasswordUpdateRequest(String password) {
+        this.password = password;
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/response/MyInfoResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/response/MyInfoResponse.java
@@ -1,0 +1,31 @@
+package com.seungwook.ktsp.domain.user.dto.response;
+
+import com.seungwook.ktsp.domain.user.entity.enums.AcademicYear;
+import com.seungwook.ktsp.domain.user.entity.enums.Campus;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class MyInfoResponse {
+
+    private final String email;
+    private final String name;
+    private final AcademicYear academicYear;
+    private final String studentNumber;
+    private final String phoneNumber;
+    private final String major;
+    private final BigDecimal previousGpa;
+    private final Campus campus;
+
+    public MyInfoResponse(String email, String name, AcademicYear academicYear, String studentNumber, String phoneNumber, String major, BigDecimal previousGpa, Campus campus) {
+        this.email = email;
+        this.name = name;
+        this.academicYear = academicYear;
+        this.studentNumber = studentNumber;
+        this.phoneNumber = phoneNumber;
+        this.major = major;
+        this.previousGpa = previousGpa;
+        this.campus = campus;
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/entity/User.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/entity/User.java
@@ -25,14 +25,17 @@ public class User extends BaseEntity {
     @Column(name = "email", nullable = false, unique = true, length = 40)
     private String email;
 
-    @Column(name = "student_number", unique = true, length = 9)
-    private String studentNumber;
+    @Column(name = "phone_number", nullable = false, unique = true, length = 13)
+    private String phoneNumber;
 
     @Column(name = "password", nullable = false, length = 60)
     private String password;
 
     @Column(name = "name", nullable = false, length = 15)
     private String name;
+
+    @Column(name = "student_number", unique = true, length = 9)
+    private String studentNumber;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "academic_year", nullable = false)
@@ -42,15 +45,8 @@ public class User extends BaseEntity {
     @Column(name = "campus", nullable = false)
     private Campus campus;
 
-    @Column(name = "phone_number", nullable = false, unique = true, length = 13)
-    private String phoneNumber;
-
     @Column(name = "major", nullable = false, length = 20)
     private String major;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false)
-    private UserRole role;
 
     @Column(name = "previous_gpa", precision = 3, scale = 2, nullable = false)
     private BigDecimal previousGpa;
@@ -58,31 +54,35 @@ public class User extends BaseEntity {
     @Column(name = "activated", nullable = false)
     private Boolean activated;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private UserRole role;
+
     @Builder(access = AccessLevel.PRIVATE)
     private User(String email, String password, String studentNumber, String name, AcademicYear academicYear, Campus campus, String phoneNumber, String major, BigDecimal previousGpa, UserRole role) {
         this.email = email;
+        this.phoneNumber = phoneNumber;
         this.password = password;
-        this.studentNumber = studentNumber;
         this.name = name;
         this.academicYear = academicYear;
+        this.studentNumber = studentNumber;
         this.campus = campus;
-        this.phoneNumber = phoneNumber;
         this.major = major;
-        this.role = role;
         this.previousGpa = previousGpa;
         this.activated = true;
+        this.role = role;
     }
 
     // 일반 유저 생성
     public static User createUser(String email, String encodedPassword, String studentNumber, String name, AcademicYear academicYear, Campus campus, String phoneNumber, String major, BigDecimal previousGpa) {
         return User.builder()
                 .email(email)
-                .password(encodedPassword)
+                .phoneNumber(phoneNumber)
                 .studentNumber(studentNumber)
+                .password(encodedPassword)
                 .name(name)
                 .academicYear(academicYear)
                 .campus(campus)
-                .phoneNumber(phoneNumber)
                 .major(major)
                 .previousGpa(previousGpa)
                 .role(UserRole.USER)
@@ -94,11 +94,11 @@ public class User extends BaseEntity {
         return User.builder()
                 .email(email)
                 .password(encodedPassword)
-                .studentNumber(studentNumber)
+                .phoneNumber(telNumber)
                 .name(name)
+                .studentNumber(studentNumber)
                 .academicYear(AcademicYear.GRADUATE)
                 .campus(Campus.CHUNCHEON)
-                .phoneNumber(telNumber)
                 .major(major)
                 .previousGpa(new BigDecimal("4.0"))
                 .role(UserRole.ADMIN)
@@ -111,23 +111,12 @@ public class User extends BaseEntity {
     }
 
     // 학년 변경
-    public void changeAcademicYear(AcademicYear newYear) {
+    public void changeUserInformation(AcademicYear newYear, String newPhoneNumber, String newMajor, BigDecimal newGpa, Campus newCampus) {
         this.academicYear = newYear;
-    }
-
-    // 전화번호 변경
-    public void changePhoneNumber(String phoneNumber) {
-        this.phoneNumber = phoneNumber;
-    }
-
-    // 전공 변경
-    public void changeMajor(String newMajor) {
+        this.phoneNumber = newPhoneNumber;
         this.major = newMajor;
-    }
-
-    // 이전학기 학점 변경
-    public void changePreviousGpa(BigDecimal newGpa) {
         this.previousGpa = newGpa;
+        this.campus = newCampus;
     }
 
     // 계정 비활성화

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/exception/UserNotFoundException.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.seungwook.ktsp.domain.user.exception;
+
+import com.seungwook.ktsp.global.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class UserNotFoundException extends BaseCustomException {
+    public UserNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+    }
+}
+

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/exception/UserUpdateFailedException.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/exception/UserUpdateFailedException.java
@@ -1,0 +1,10 @@
+package com.seungwook.ktsp.domain.user.exception;
+
+import com.seungwook.ktsp.global.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class UserUpdateFailedException extends BaseCustomException {
+    public UserUpdateFailedException(HttpStatus httpStatus, String message) {
+        super(httpStatus, message);
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
@@ -1,0 +1,18 @@
+package com.seungwook.ktsp.domain.user.mapper;
+
+import com.seungwook.ktsp.domain.user.dto.response.MyInfoResponse;
+import com.seungwook.ktsp.domain.user.entity.User;
+
+public class UserResponseMapper {
+
+    public static MyInfoResponse toMyinfoResponse(User user) {
+        return new MyInfoResponse(user.getEmail(),
+                user.getName(),
+                user.getAcademicYear(),
+                user.getStudentNumber(),
+                user.getPhoneNumber(),
+                user.getMajor(),
+                user.getPreviousGpa(),
+                user.getCampus());
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
@@ -13,5 +13,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByPhoneNumber(String phoneNumber);
 
+    Optional<User> findById(long userId);
+
     Optional<User> findByStudentNumber(String studentNumber);
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
@@ -13,7 +13,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByPhoneNumber(String phoneNumber);
 
-    Optional<User> findById(long userId);
-
     Optional<User> findByStudentNumber(String studentNumber);
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
@@ -26,8 +26,8 @@ public class UserService {
 
     // 내 정보 수정
     @Transactional
-    public User updateUserInformation(long userID, MyInfoUpdateRequest request) {
-        User user = findById(userID);
+    public User updateUserInformation(long userId, MyInfoUpdateRequest request) {
+        User user = findById(userId);
 
         String newPhoneNumber = request.getPhoneNumber();
         String oldPhoneNumber = user.getPhoneNumber();

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
@@ -1,14 +1,60 @@
 package com.seungwook.ktsp.domain.user.service;
 
+import com.seungwook.ktsp.domain.user.dto.request.MyInfoUpdateRequest;
+import com.seungwook.ktsp.domain.user.entity.User;
+import com.seungwook.ktsp.domain.user.exception.UserUpdateFailedException;
+import com.seungwook.ktsp.domain.user.exception.UserNotFoundException;
 import com.seungwook.ktsp.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
+    // 내 정보 조회
+    @Transactional(readOnly = true)
+    public User getUserInformation(long userId) {
+        return findById(userId);
+    }
 
+    // 내 정보 수정
+    @Transactional
+    public User updateUserInformation(long userID, MyInfoUpdateRequest request) {
+        User user = findById(userID);
+
+        String newPhoneNumber = request.getPhoneNumber();
+        String oldPhoneNumber = user.getPhoneNumber();
+        if (!newPhoneNumber.equals(oldPhoneNumber)) {
+            if(userRepository.existsByPhoneNumber(newPhoneNumber))
+                throw new UserUpdateFailedException(HttpStatus.CONFLICT, "이미 등록된 전화번호입니다.");
+        }
+
+        user.changeUserInformation(request.getAcademicYear(),
+                request.getPhoneNumber(),
+                request.getMajor(),
+                request.getPreviousGpa(),
+                request.getCampus());
+
+        return user;
+    }
+
+    // 비밀번호 변경
+    @Transactional
+    public void updatePassword(long userId, String password){
+        User user = findById(userId);
+
+        // 암호화 저장
+        user.changePassword(passwordEncoder.encode(password));
+    }
+
+    private User findById(long userId) {
+        return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+    }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/dto/UserSession.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/dto/UserSession.java
@@ -22,14 +22,13 @@ public class UserSession implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @EqualsAndHashCode.Include
-    private final String studentNumber;
-
-    private final String name;
+    private final long id;
+    private final String email;
     private final UserRole role;
 
-    public UserSession(String studentNumber, String name, UserRole role) {
-        this.studentNumber = studentNumber;
-        this.name = name;
+    public UserSession(long id, String email, UserRole role) {
+        this.id = id;
+        this.email = email;
         this.role = role;
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
 
     // 요청 사용자 식별 메서드
     @Transactional(readOnly = true)
-    public User getUser() {
+    public long getUser() {
         // 현재 요청의 SecurityContext에서 인증 객체 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
@@ -52,9 +52,7 @@ public class AuthService {
             throw new UserContextException("잘못된 인증 세션입니다.");
         }
 
-        // 세션에 저장된 학번으로 사용자 조회, 존재하지 않으면 예외 발생
-        return userRepository.findByStudentNumber(session.getStudentNumber())
-                .orElseThrow(() -> new UserContextException("사용자를 찾을 수 없습니다."));
+        return session.getId();
     }
 
     // 로그인
@@ -118,7 +116,7 @@ public class AuthService {
 
     // 인증 세션 객체(UserSession) 생성
     private UserSession createUserSession(User user) {
-        return new UserSession(user.getStudentNumber(), user.getName(), user.getRole());
+        return new UserSession(user.getId(), user.getEmail(), user.getRole());
     }
 
     // UserSession으로 Spring Security 인증 객체 생성

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
 
     // 요청 사용자 식별 메서드
     @Transactional(readOnly = true)
-    public long getUser() {
+    public long getUserId() {
         // 현재 요청의 SecurityContext에서 인증 객체 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 


### PR DESCRIPTION
## 연관된 이슈
#5 회원정보 조회/수정
<br>

## 작업 내용
1. 회원정보 조회 기능 추가
> 이메일, 이름, 학년, 학번, 전화번호, 전공, 직전학기 성적, 캠퍼스 조회 가능

2. 회원정보 수정 기능 추가
> 비밀번호, 학년, 전화번호, 전공, 직전학기 성적, 캠퍼스 수정 가능

3. UserSession 필드 변경
> studentNumber, name, role -> id, mail, role

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 내 정보 조회, 수정, 비밀번호 변경 기능이 추가되었습니다. 이제 사용자는 자신의 정보를 확인하고 업데이트할 수 있습니다.

* **버그 수정**
  * 사용자 정보 수정 시 전화번호 중복 검증이 강화되었습니다.

* **개선사항**
  * 사용자 세션 정보가 학번/이름에서 ID/이메일 기반으로 변경되어 보안성과 일관성이 향상되었습니다.

* **기타**
  * 일부 내부 예외 및 응답 구조가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->