### PR TITLE
feat: 비밀번호를 잊었을 때, 초기화 기능

### DIFF
--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/MyInfoController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/MyInfoController.java
@@ -11,20 +11,18 @@ import com.seungwook.ktsp.global.response.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/service/user")
 public class MyInfoController {
 
     private final AuthService authService;
     private final UserService userService;
 
     // 내 정보 조회
-    @GetMapping("/service/user")
+    @GetMapping
     public ResponseEntity<Response<MyInfoResponse>> getMyInfo() {
 
         User user = userService.getUserInformation(authService.getUserId());
@@ -37,7 +35,7 @@ public class MyInfoController {
     }
 
     // 내 정보 수정
-    @PatchMapping("/service/user")
+    @PatchMapping
     public ResponseEntity<Response<MyInfoResponse>> updateMyInfo(@Valid @RequestBody MyInfoUpdateRequest request) {
 
         User user = userService.updateUserInformation(authService.getUserId(), request);
@@ -50,7 +48,7 @@ public class MyInfoController {
     }
 
     // 비밀번호 변경
-    @PatchMapping("/service/password")
+    @PatchMapping("/password")
     public ResponseEntity<Response<Void>> updatePassword(@Valid @RequestBody PasswordUpdateRequest request) {
 
         userService.updatePassword(authService.getUserId(), request.getPassword());

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
@@ -14,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByPhoneNumber(String phoneNumber);
 
     Optional<User> findByStudentNumber(String studentNumber);
+
+    Optional<User> findByEmail(String email);
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
@@ -6,11 +6,13 @@ import com.seungwook.ktsp.domain.user.exception.UserUpdateFailedException;
 import com.seungwook.ktsp.domain.user.exception.UserNotFoundException;
 import com.seungwook.ktsp.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -42,6 +44,8 @@ public class UserService {
                 request.getPreviousGpa(),
                 request.getCampus());
 
+        log.info("회원정보 변경 성공 - {}({})", user.getName(), user.getStudentNumber());
+
         return user;
     }
 
@@ -52,6 +56,8 @@ public class UserService {
 
         // 암호화 저장
         user.changePassword(passwordEncoder.encode(password));
+
+        log.info("비밀번호 변경 성공 - {}({})", user.getName(), user.getStudentNumber());
     }
 
     private User findById(long userId) {

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/AccountController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/AccountController.java
@@ -1,9 +1,10 @@
 package com.seungwook.ktsp.global.auth.controller;
 
 import com.seungwook.ktsp.global.auth.dto.request.LoginRequest;
+import com.seungwook.ktsp.global.auth.dto.request.PasswordResetRequest;
 import com.seungwook.ktsp.global.auth.dto.request.RegisterRequest;
 import com.seungwook.ktsp.global.auth.dto.response.LoginResponse;
-import com.seungwook.ktsp.global.auth.service.RegisterService;
+import com.seungwook.ktsp.global.auth.service.AccountService;
 import com.seungwook.ktsp.global.auth.service.AuthService;
 import com.seungwook.ktsp.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/account")
 public class AccountController {
 
-    private final RegisterService registerService;
+    private final AccountService accountService;
     private final AuthService authService;
 
     // 회원가입
@@ -31,7 +32,7 @@ public class AccountController {
     @PostMapping("/register")
     public ResponseEntity<Response<Void>> register(@Valid @RequestBody RegisterRequest request, HttpServletRequest httpRequest) {
 
-        registerService.register(request, httpRequest);
+        accountService.register(request, httpRequest);
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("회원가입 성공")
@@ -48,6 +49,18 @@ public class AccountController {
         return ResponseEntity.ok(Response.<LoginResponse>builder()
                 .message("로그인 성공")
                 .data(response)
+                .build());
+    }
+
+    // 비밀번호 찾기
+    @Operation(summary = "비밀번호 찾기", description = "이메일 인증을 완료한 사용자 비밀번호 변경 가능")
+    @PostMapping("/find-password")
+    public ResponseEntity<Response<Void>> findPassword(@Valid @RequestBody PasswordResetRequest request, HttpServletRequest httpServletRequest) {
+
+        accountService.resetPassword(request, httpServletRequest);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("비밀번호 변경 성공")
                 .build());
     }
 

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/dto/request/PasswordResetRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/dto/request/PasswordResetRequest.java
@@ -1,0 +1,27 @@
+package com.seungwook.ktsp.global.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class PasswordResetRequest {
+
+    @Schema(description = "이메일", example = "user123@kangwon.ac.kr")
+    @NotBlank(message = "이메일은 필수 항목입니다.")
+    @Size(min = 16, max = 40, message = "이메일은 최소 16자 ~ 최대 40자 입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private final String email;
+
+    @Schema(description = "사용자 비밀번호", example = "SecurePass123!")
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 ~ 최대 30자 입니다.")
+    private final String password;
+
+    public PasswordResetRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/dto/request/RegisterRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/dto/request/RegisterRequest.java
@@ -20,7 +20,7 @@ public class RegisterRequest {
     @Schema(description = "사용자 학번", example = "202312345")
     @NotBlank(message = "학번은 필수 항목입니다.")
     @Size(min = 9, max = 9, message = "학번은 9자 입니다.")
-    @Pattern(regexp = "^\\d{9}$", message = "학번은 숫자 9자 입니다.")
+    @Pattern(regexp = "^[0-9]{9}$", message = "학번은 숫자 9자 입니다.")
     private final String studentNumber;
 
     @Schema(description = "사용자 비밀번호", example = "SecurePass123!")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AccountService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AccountService.java
@@ -1,7 +1,9 @@
 package com.seungwook.ktsp.global.auth.service;
 
 import com.seungwook.ktsp.domain.user.entity.User;
+import com.seungwook.ktsp.domain.user.exception.UserNotFoundException;
 import com.seungwook.ktsp.domain.user.repository.UserRepository;
+import com.seungwook.ktsp.global.auth.dto.request.PasswordResetRequest;
 import com.seungwook.ktsp.global.auth.dto.request.RegisterRequest;
 import com.seungwook.ktsp.global.auth.exception.RegisterFailedException;
 import com.seungwook.ktsp.global.auth.exception.StudentNumberException;
@@ -16,30 +18,25 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Year;
-import java.util.regex.Pattern;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class RegisterService {
+public class AccountService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthCodeRedisService authCodeRedisService;
 
-    // 학번 형식
-    private static final String STUDENT_NUMBER_PATTERN = "^[0-9]{9}$";
-
     // 회원가입
     @Transactional
     public void register(RegisterRequest request, HttpServletRequest httpRequest) {
 
-        if (!request.getEmail().endsWith("@kangwon.ac.kr"))
-            throw new RegisterFailedException(HttpStatus.BAD_REQUEST, "강원대학교 이메일이 아닙니다.");
+        // 강원대학교 이메일인지 검사
+        checkEmailDomain(request.getEmail());
 
         // 이메일 인증 완료여부 검사
-        if (!authCodeRedisService.existVerifiedEmail(request.getEmail()))
-            throw new EmailVerifyException(HttpStatus.CONFLICT, "이메일 인증이 완료되지 않았습니다.");
+        isVerifyEmail(request.getEmail());
 
         // 학번 유효성 검사
         validStudentNumber(request.getStudentNumber());
@@ -52,21 +49,38 @@ public class RegisterService {
         userRepository.save(newUser);
 
         // 인증 완료 이메일 제거
-        authCodeRedisService.deleteVerifiedEmail(request.getEmail());
+        deleteVerifiedEmailFromRedis(request.getEmail());
 
         log.info("회원가입 성공 - {}({} / {})", newUser.getName(), newUser.getStudentNumber(), IpUtil.getClientIP(httpRequest));
     }
 
+    // 비밀번호 찾기
+    @Transactional
+    public void resetPassword(PasswordResetRequest request, HttpServletRequest httpRequest) {
+
+        // 강원대학교 이메일인지 검사
+        checkEmailDomain(request.getEmail());
+
+        // 이메일 인증 완료여부 검사
+        isVerifyEmail(request.getEmail());
+
+        // 회원 조회
+        User user = userRepository.findByEmail(request.getEmail()).orElseThrow(UserNotFoundException::new);
+
+        // 비밀번호 변경
+        user.changePassword(passwordEncoder.encode(request.getPassword()));
+
+        // 인증 완료 이메일 제거
+        deleteVerifiedEmailFromRedis(request.getEmail());
+
+        log.info("비밀번호 초기화 성공 - {}({} / {})", user.getName(), user.getStudentNumber(), IpUtil.getClientIP(httpRequest));
+    }
+
     // 학번 유효성 검사
     private void validStudentNumber(String studentNumber) {
-        if (!Pattern.matches(STUDENT_NUMBER_PATTERN, studentNumber)) throw new StudentNumberException();
-
         int admissionYear = Integer.parseInt(studentNumber.substring(0, 4)); // 학번의 첫 4자리 (입학년도)
         int currentYear = Year.now().getValue(); // 현재 년도
-
-        // 입학년도가 현재 년도보다 크면 안 됨
-        if (admissionYear > currentYear) throw new StudentNumberException();
-
+        if (admissionYear > currentYear) throw new StudentNumberException(); // 입학년도가 현재 년도보다 크면 안 됨
     }
 
     // 이메일, 학번, 전화번호 중복 검사
@@ -87,5 +101,22 @@ public class RegisterService {
                 request.getPhoneNumber(),
                 request.getMajor(),
                 request.getPreviousGpa());
+    }
+
+    // 강원대학교 이메일인지 검증
+    private void checkEmailDomain(String email) {
+        if (!email.endsWith("@kangwon.ac.kr"))
+            throw new EmailVerifyException(HttpStatus.BAD_REQUEST, "강원대학교 이메일이 아닙니다.");
+    }
+
+    // 인증된 이메일인지 확인
+    private void isVerifyEmail(String email) {
+        if (!authCodeRedisService.existVerifiedEmail(email))
+            throw new EmailVerifyException(HttpStatus.CONFLICT, "이메일 인증이 완료되지 않았습니다.");
+    }
+
+    // 인증 완료 이메일 레디스에서 제거
+    private void deleteVerifiedEmailFromRedis(String email) {
+        authCodeRedisService.deleteVerifiedEmail(email);
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/VerificationService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/VerificationService.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -17,7 +18,7 @@ public class VerificationService {
     private final AuthCodeRedisService authCodeRedisService;
 
     // 인증코드 허용 문자 집합
-    private static final char[] ALPHA_NUMERIC = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
+    private final char[] ALPHA_NUMERIC = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
 
     // SecureRandom
     private static final SecureRandom RANDOM = new SecureRandom();
@@ -40,9 +41,12 @@ public class VerificationService {
         }
 
         if (!authCode.equals(code)) {
-            log.warn("인증코드 검증 실패 - email: {}, 예상 값: {}, 입력 값: {}", email, authCode, code);
-            authCodeRedisService.incrementFailCount(email); // 실패 횟수 증가
+            log.warn("인증코드 검증 실패 - email: {}", email);
 
+            // 실패 횟수 증가
+            authCodeRedisService.incrementFailCount(email);
+
+            // 실패 횟수 5회 이상 -> 레디스에서 인증코드 삭제
             int failCount = authCodeRedisService.getFailCount(email);
             if(failCount >= 5) {
                 authCodeRedisService.deleteAuthCode(email);
@@ -52,7 +56,7 @@ public class VerificationService {
             throw new EmailVerifyException("현재 " + failCount + "회 잘못된 인증번호를 입력하였습니다.");
         }
 
-        // 인증 성공시 레디스에서 키 삭제
+        // 인증 성공시 레디스에서 인증코드 삭제
         authCodeRedisService.deleteAuthCode(email);
 
         // 이메일 인증 성공여부 저장(TTL: 60분)
@@ -62,10 +66,10 @@ public class VerificationService {
 
     // 인증코드 생성
     private String generateVerifyCode() {
-        int length = 6;
+        int verifyCodeLength = 6;
 
-        StringBuilder sb = new StringBuilder(length);
-        for (int i = 0; i < length; i++) {
+        StringBuilder sb = new StringBuilder(verifyCodeLength);
+        for (int i = 0; i < verifyCodeLength; i++) {
             char c = ALPHA_NUMERIC[RANDOM.nextInt(ALPHA_NUMERIC.length)];
             sb.append(c);
         }
@@ -73,7 +77,7 @@ public class VerificationService {
         return sb.toString();
     }
 
-    //
+    // 강원대학교 이메일인지 검증
     private void checkEmailDomain(String email) {
         if (!email.endsWith("@kangwon.ac.kr"))
             throw new EmailVerifyException(HttpStatus.BAD_REQUEST, "강원대학교 이메일이 아닙니다.");


### PR DESCRIPTION
## 연관된 이슈
#8 비밀번호를 잊었을 때, 초기화할 수 있는 기능

## 작업 내용
- 비밀번호를 잊었을 때, 이메일 인증을 통해 비밀번호를 초기화할 수 있는 기능 구현
> 이메일로 인증 코드 발송 -> 인증 확인 -> 인증된 이메일로 회원 조회 -> 회원 비밀번호 초기화
