### PR TITLE
feat/security: 인증 코드 발송 쿨다운 로직 강화, 개인정보 로그 마스킹 처리

### DIFF
--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
@@ -5,6 +5,7 @@ import com.seungwook.ktsp.domain.user.entity.User;
 
 public class UserResponseMapper {
 
+    // MyInfoResponse로 변환
     public static MyInfoResponse toMyinfoResponse(User user) {
         return new MyInfoResponse(user.getEmail(),
                 user.getName(),

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
@@ -44,7 +44,7 @@ public class UserService {
                 request.getPreviousGpa(),
                 request.getCampus());
 
-        log.info("회원정보 변경 성공 - {}({})", user.getName(), user.getStudentNumber());
+        log.info("회원정보 변경 성공 - userId: {}", user.getId());
 
         return user;
     }
@@ -57,7 +57,7 @@ public class UserService {
         // 암호화 저장
         user.changePassword(passwordEncoder.encode(password));
 
-        log.info("비밀번호 변경 성공 - {}({})", user.getName(), user.getStudentNumber());
+        log.info("비밀번호 변경 성공 - userId: {}", user.getId());
     }
 
     private User findById(long userId) {

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/EmailVerifyController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/EmailVerifyController.java
@@ -7,8 +7,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,10 +28,11 @@ public class EmailVerifyController {
     @PostMapping("/{email}/send")
     public ResponseEntity<Response<Void>> mailSend(
             @Parameter(description = "이메일", example = "user123@kangwon.ac.kr")
+            @Size(min = 16, max = 40, message = "이메일은 최소 16자 ~ 최대 40자 입니다.")
             @Email(message = "이메일 형식이 올바르지 않습니다.")
-            @PathVariable String email) throws MessagingException {
+            @PathVariable String email, HttpServletRequest httpServletRequest) throws MessagingException {
 
-        verificationService.sendAuthCode(email);
+        verificationService.sendAuthCode(email, httpServletRequest);
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("인증코드 메일 발송 성공")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AccountService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AccountService.java
@@ -51,7 +51,7 @@ public class AccountService {
         // 인증 완료 이메일 제거
         deleteVerifiedEmailFromRedis(request.getEmail());
 
-        log.info("회원가입 성공 - {}({} / {})", newUser.getName(), newUser.getStudentNumber(), IpUtil.getClientIP(httpRequest));
+        log.info("회원가입 성공 - userId: {}({})", newUser.getId(), IpUtil.getClientIP(httpRequest));
     }
 
     // 비밀번호 찾기
@@ -73,7 +73,7 @@ public class AccountService {
         // 인증 완료 이메일 제거
         deleteVerifiedEmailFromRedis(request.getEmail());
 
-        log.info("비밀번호 초기화 성공 - {}({} / {})", user.getName(), user.getStudentNumber(), IpUtil.getClientIP(httpRequest));
+        log.info("비밀번호 초기화 성공 - userId: {}({})", user.getId(), IpUtil.getClientIP(httpRequest));
     }
 
     // 학번 유효성 검사

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthCodeRedisService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthCodeRedisService.java
@@ -17,6 +17,7 @@ public class AuthCodeRedisService {
     private static final String VERIFY_CODE_PREFIX = "verify-code:";
     private static final String VERIFIED_EMAIL_PREFIX = "verified-email:";
     private static final String COOLDOWN_KEY_PREFIX = "verify-cooldown:";
+    private static final String IP_COOLDOWN_KEY_PREFIX = "verify-ip-cooldown:";
 
     // 보안코드 조회
     public String getAuthCode(String email) {
@@ -84,13 +85,24 @@ public class AuthCodeRedisService {
     }
 
 
-    // 쿨다운이 지났는지 확인
-    public boolean isInCooldown(String email) {
-        return template.hasKey(COOLDOWN_KEY_PREFIX + email);
+    // (이메일 + IP)쿨다운 기간인지 확인
+    public boolean isInCooldown(String email, String ip) {
+        return template.hasKey(getEmailCooldownKey(email)) || template.hasKey(getIpCooldownKey(ip));
     }
 
-    // 이메일 지속 요청 방지
-    public void setCooldown(String email, long ttlSeconds) {
-        template.opsForValue().set(COOLDOWN_KEY_PREFIX + email, "1", Duration.ofSeconds(ttlSeconds));
+    // (이메일 + IP)쿨다운 설정
+    public void setCooldown(String email, String ip, long ttlSeconds) {
+        template.opsForValue().set(getEmailCooldownKey(email), "1", Duration.ofSeconds(ttlSeconds));
+        template.opsForValue().set(getIpCooldownKey(ip), "1", Duration.ofSeconds(ttlSeconds));
+    }
+
+    // 이메일 쿨다운 여부
+    private String getEmailCooldownKey(String email) {
+        return COOLDOWN_KEY_PREFIX + email;
+    }
+
+    // IP 쿨다운 여부
+    private String getIpCooldownKey(String ip) {
+        return IP_COOLDOWN_KEY_PREFIX + ip;
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/VerificationService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/VerificationService.java
@@ -1,7 +1,9 @@
 package com.seungwook.ktsp.global.auth.service;
 
 import com.seungwook.ktsp.global.auth.exception.EmailVerifyException;
+import com.seungwook.ktsp.global.auth.utils.MaskingUtil;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,9 +26,9 @@ public class VerificationService {
     private static final SecureRandom RANDOM = new SecureRandom();
 
     // 인증 코드 발송
-    public void sendAuthCode(String email) throws MessagingException {
+    public void sendAuthCode(String email, HttpServletRequest httpServletRequest) throws MessagingException {
         checkEmailDomain(email);
-        emailService.sendVerificationEmail(email, generateVerifyCode());
+        emailService.sendVerificationEmail(email, generateVerifyCode(), httpServletRequest);
     }
 
     // 인증코드 검증
@@ -41,7 +43,7 @@ public class VerificationService {
         }
 
         if (!authCode.equals(code)) {
-            log.warn("인증코드 검증 실패 - email: {}", email);
+            log.warn("인증코드 검증 실패 - email: {}", MaskingUtil.maskEmail(email));
 
             // 실패 횟수 증가
             authCodeRedisService.incrementFailCount(email);
@@ -61,7 +63,7 @@ public class VerificationService {
 
         // 이메일 인증 성공여부 저장(TTL: 60분)
         authCodeRedisService.setEmailAsVerified(email, 60 * 60L);
-        log.info("인증코드 검증 성공 - email: {}", email);
+        log.info("인증코드 검증 성공 - email: {}", MaskingUtil.maskEmail(email));
     }
 
     // 인증코드 생성
@@ -82,4 +84,6 @@ public class VerificationService {
         if (!email.endsWith("@kangwon.ac.kr"))
             throw new EmailVerifyException(HttpStatus.BAD_REQUEST, "강원대학교 이메일이 아닙니다.");
     }
+
+
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/utils/MaskingUtil.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/utils/MaskingUtil.java
@@ -1,0 +1,10 @@
+package com.seungwook.ktsp.global.auth.utils;
+
+public class MaskingUtil {
+
+    public static String maskEmail(String email) {
+        int at = email.indexOf('@');
+        if (at < 4) return "****" + email.substring(at); // 4글자 미만이면 전부 마스킹
+        return "****" + email.substring(4);
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
Close #10 [Bug] 인증코드 발송 기능 남용 가능

## 작업 내용
- 보안코드 이메일 발송 쿨다운 로직 강화

| 시나리오                          | 남용 가능성 | 설명                                      |
|-----------------------------------|------------|-------------------------------------------|
| 동일 이메일 + 동일 IP            | 제한됨   | 이메일 키, IP 키 모두 작동                |
| 다른 이메일 + 동일 IP            | 제한됨   | IP 기준 키가 막음                         |
| 다른 IP + 동일 이메일            | 제한됨   | 이메일 기준 키가 막음                     |
| IP 바꾸고, 이메일 바꿔서 공격     | 일부 우회 가능 | Tor, VPN 우회 가능    |
> 동일 IP 또는 동일 이메일에 대해서 쿨다운 처리
<br>

- 쿨다운 기간 연장
> 기존 1분 -> 3분으로 연장
<br>

- 개인정보 로그 최소화 및 마스킹 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이메일 주소를 부분적으로 가리는 마스킹 기능이 도입되었습니다.

* **버그 수정**
  * 이메일 인증 요청 시 이메일 형식에 대한 길이 제한(16~40자)이 추가되었습니다.
  * 인증 코드 발송 시 이메일과 IP 주소 모두에 쿨다운이 적용되어, 동일 이메일 또는 IP에서의 반복 요청이 제한됩니다.

* **개선 사항**
  * 이메일 인증 및 인증 코드 관련 로그에 이메일이 마스킹되어 노출되지 않도록 개선되었습니다.
  * 인증, 회원가입, 비밀번호 변경 등 주요 로그에서 사용자 이름 대신 사용자 ID가 기록됩니다.
  * 인증 코드 쿨다운 시간이 60초에서 180초로 연장되었습니다.
  * 비활성화된 계정으로 로그인 시 경고 로그가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->