### PR TITLE
Feat/user User 관련 읽기/쓰기 컨트롤러 분리, 회원 프로필 조회 기능 추가

### DIFF
--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserCommandController.java
@@ -1,7 +1,7 @@
 package com.seungwook.ktsp.domain.user.controller;
 
-import com.seungwook.ktsp.domain.user.dto.request.UserInfoUpdateRequest;
 import com.seungwook.ktsp.domain.user.dto.request.PasswordUpdateRequest;
+import com.seungwook.ktsp.domain.user.dto.request.UserInfoUpdateRequest;
 import com.seungwook.ktsp.domain.user.dto.response.UserInfoResponse;
 import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.mapper.UserResponseMapper;
@@ -13,33 +13,22 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "User Information", description = "회원 정보 조회/수정 API")
+@Tag(name = "User Command", description = "회원 정보 수정 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/service/user")
-public class UserInfoController {
+public class UserCommandController {
 
     private final AuthService authService;
     private final UserService userService;
 
-    // 내 정보 조회
-    @Operation(summary = "회원 정보 조회", description = "이메일, 이름, 학년, 학번, 전화번호, 전공, 직전학기 성적, 캠퍼스 조회")
-    @GetMapping
-    public ResponseEntity<Response<UserInfoResponse>> getMyInfo() {
-
-        User user = userService.getUserInformation(authService.getUserId());
-        UserInfoResponse response = UserResponseMapper.toUserInfoResponse(user);
-
-        return ResponseEntity.ok(Response.<UserInfoResponse>builder()
-                .message("내 정보를 불러왔습니다.")
-                .data(response)
-                .build());
-    }
-
     // 내 정보 수정
-    @Operation(summary = "회원 정보 수정", description = "학년, 전화번호, 전공, 직전학기 성적, 캠퍼스 등 수정")
+    @Operation(summary = "회원 정보 수정", description = "학년, 전화번호, 전공, 직전학기 성적, 캠퍼스, 자기소개 등 수정")
     @PatchMapping
     public ResponseEntity<Response<UserInfoResponse>> updateMyInfo(@Valid @RequestBody UserInfoUpdateRequest request) {
 

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserInfoController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserInfoController.java
@@ -1,57 +1,63 @@
 package com.seungwook.ktsp.domain.user.controller;
 
-import com.seungwook.ktsp.domain.user.dto.request.MyInfoUpdateRequest;
+import com.seungwook.ktsp.domain.user.dto.request.UserInfoUpdateRequest;
 import com.seungwook.ktsp.domain.user.dto.request.PasswordUpdateRequest;
-import com.seungwook.ktsp.domain.user.dto.response.MyInfoResponse;
+import com.seungwook.ktsp.domain.user.dto.response.UserInfoResponse;
 import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.mapper.UserResponseMapper;
 import com.seungwook.ktsp.domain.user.service.UserService;
 import com.seungwook.ktsp.global.auth.service.AuthService;
 import com.seungwook.ktsp.global.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "User Information", description = "회원 정보 조회/수정 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/service/user")
-public class MyInfoController {
+public class UserInfoController {
 
     private final AuthService authService;
     private final UserService userService;
 
     // 내 정보 조회
+    @Operation(summary = "회원 정보 조회", description = "이메일, 이름, 학년, 학번, 전화번호, 전공, 직전학기 성적, 캠퍼스 조회")
     @GetMapping
-    public ResponseEntity<Response<MyInfoResponse>> getMyInfo() {
+    public ResponseEntity<Response<UserInfoResponse>> getMyInfo() {
 
         User user = userService.getUserInformation(authService.getUserId());
-        MyInfoResponse response = UserResponseMapper.toMyinfoResponse(user);
+        UserInfoResponse response = UserResponseMapper.toUserInfoResponse(user);
 
-        return ResponseEntity.ok(Response.<MyInfoResponse>builder()
+        return ResponseEntity.ok(Response.<UserInfoResponse>builder()
                 .message("내 정보를 불러왔습니다.")
                 .data(response)
                 .build());
     }
 
     // 내 정보 수정
+    @Operation(summary = "회원 정보 수정", description = "학년, 전화번호, 전공, 직전학기 성적, 캠퍼스 등 수정")
     @PatchMapping
-    public ResponseEntity<Response<MyInfoResponse>> updateMyInfo(@Valid @RequestBody MyInfoUpdateRequest request) {
+    public ResponseEntity<Response<UserInfoResponse>> updateMyInfo(@Valid @RequestBody UserInfoUpdateRequest request) {
 
         User user = userService.updateUserInformation(authService.getUserId(), request);
-        MyInfoResponse response = UserResponseMapper.toMyinfoResponse(user);
+        UserInfoResponse response = UserResponseMapper.toUserInfoResponse(user);
 
-        return ResponseEntity.ok(Response.<MyInfoResponse>builder()
+        return ResponseEntity.ok(Response.<UserInfoResponse>builder()
                 .message("내 정보를 수정했습니다.")
                 .data(response)
                 .build());
     }
 
     // 비밀번호 변경
+    @Operation(summary = "회원 비밀번호 변경", description = "기존 비밀번호와 신규 비밀번호를 제출하면 신규 비밀번호로 변경")
     @PatchMapping("/password")
     public ResponseEntity<Response<Void>> updatePassword(@Valid @RequestBody PasswordUpdateRequest request) {
 
-        userService.updatePassword(authService.getUserId(), request.getPassword());
+        userService.updatePassword(authService.getUserId(), request);
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("비밀번호가 변경되었습니다.")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserQueryController.java
@@ -1,0 +1,52 @@
+package com.seungwook.ktsp.domain.user.controller;
+
+import com.seungwook.ktsp.domain.user.dto.response.UserInfoResponse;
+import com.seungwook.ktsp.domain.user.dto.response.UserProfileResponse;
+import com.seungwook.ktsp.domain.user.entity.User;
+import com.seungwook.ktsp.domain.user.mapper.UserResponseMapper;
+import com.seungwook.ktsp.domain.user.service.UserService;
+import com.seungwook.ktsp.global.auth.service.AuthService;
+import com.seungwook.ktsp.global.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "User Query", description = "회원 정보 조회 API (내 정보 및 타인 프로필)")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/service/user")
+public class UserQueryController {
+
+    private final AuthService authService;
+    private final UserService userService;
+
+    // 내 정보 조회
+    @Operation(summary = "회원 정보 조회", description = "이메일, 이름, 학년, 학번, 전화번호, 전공, 직전학기 성적, 캠퍼스, 자기소개 조회")
+    @GetMapping
+    public ResponseEntity<Response<UserInfoResponse>> getMyInfo() {
+
+        User user = userService.getUserInformation(authService.getUserId());
+        UserInfoResponse response = UserResponseMapper.toUserInfoResponse(user);
+
+        return ResponseEntity.ok(Response.<UserInfoResponse>builder()
+                .message("내 정보를 불러왔습니다.")
+                .data(response)
+                .build());
+    }
+
+    // 특정 회원 프로필 조회
+    @Operation(summary = "특정 회원 프로필 조회", description = "특정 회원의 이름, 전공, 학번 조회")
+    @GetMapping("/{userId}")
+    public ResponseEntity<Response<UserProfileResponse>> getUserProfile(@PathVariable Long userId) {
+
+        User user = userService.getUserInformation(userId);
+        UserProfileResponse response = UserResponseMapper.toUserProfileResponse(user);
+
+        return ResponseEntity.ok(Response.<UserProfileResponse>builder()
+                .message("회원 프로필 조회에 성공했습니다.")
+                .data(response)
+                .build());
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserQueryController.java
@@ -8,6 +8,7 @@ import com.seungwook.ktsp.domain.user.service.UserService;
 import com.seungwook.ktsp.global.auth.service.AuthService;
 import com.seungwook.ktsp.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -39,7 +40,9 @@ public class UserQueryController {
     // 특정 회원 프로필 조회
     @Operation(summary = "특정 회원 프로필 조회", description = "특정 회원의 이름, 전공, 학번 조회")
     @GetMapping("/{userId}")
-    public ResponseEntity<Response<UserProfileResponse>> getUserProfile(@PathVariable Long userId) {
+    public ResponseEntity<Response<UserProfileResponse>> getUserProfile(
+            @Parameter(description = "UserId(PK)", example = "1")
+            @PathVariable Long userId) {
 
         User user = userService.getUserInformation(userId);
         UserProfileResponse response = UserResponseMapper.toUserProfileResponse(user);

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/PasswordUpdateRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/PasswordUpdateRequest.java
@@ -8,12 +8,18 @@ import lombok.Getter;
 @Getter
 public class PasswordUpdateRequest {
 
-    @Schema(description = "사용자 비밀번호", example = "SecurePass123!")
-    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Schema(description = "기존 비밀번호", example = "oldPassword123!")
+    @NotBlank(message = "기존 비밀번호를 입력해주세요.")
     @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 ~ 최대 30자 입니다.")
-    private final String password;
+    private final String oldPassword;
 
-    public PasswordUpdateRequest(String password) {
-        this.password = password;
+    @Schema(description = "신규 비밀번호", example = "newPassword123!")
+    @NotBlank(message = "변경할 비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 ~ 최대 30자 입니다.")
+    private final String newPassword;
+
+    public PasswordUpdateRequest(String oldPassword, String newPassword) {
+        this.oldPassword = oldPassword;
+        this.newPassword = newPassword;
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/UserInfoUpdateRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/UserInfoUpdateRequest.java
@@ -38,7 +38,7 @@ public class UserInfoUpdateRequest {
     @NotNull(message = "캠퍼스는 필수 항목입니다.")
     private final Campus campus;
 
-    @Schema(description = "자기소개 (최대 255자)", example = "안녕하세요. 백엔드 개발자 홍길동입니다.")
+    @Schema(description = "자기소개", example = "안녕하세요. 백엔드 개발자 홍길동입니다.")
     @Size(max = 255)
     private final String introduction;
 

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/UserInfoUpdateRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/UserInfoUpdateRequest.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import java.math.BigDecimal;
 
 @Getter
-public class MyInfoUpdateRequest {
+public class UserInfoUpdateRequest {
 
     @Schema(description = "사용자 학년", example = "FIRST_YEAR, SECOND_YEAR, THIRD_YEAR, FOURTH_YEAR, GRADUATE")
     @NotNull(message = "학년은 필수 항목입니다.")
@@ -38,11 +38,16 @@ public class MyInfoUpdateRequest {
     @NotNull(message = "캠퍼스는 필수 항목입니다.")
     private final Campus campus;
 
-    public MyInfoUpdateRequest(AcademicYear academicYear, String phoneNumber, String major, BigDecimal previousGpa, Campus campus) {
+    @Schema(description = "자기소개 (최대 255자)", example = "안녕하세요. 백엔드 개발자 홍길동입니다.")
+    @Size(max = 255)
+    private final String introduction;
+
+    public UserInfoUpdateRequest(AcademicYear academicYear, String phoneNumber, String major, BigDecimal previousGpa, Campus campus, String introduction) {
         this.academicYear = academicYear;
         this.phoneNumber = phoneNumber;
         this.major = major;
         this.previousGpa = previousGpa;
         this.campus = campus;
+        this.introduction = introduction;
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/response/UserInfoResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/response/UserInfoResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import java.math.BigDecimal;
 
 @Getter
-public class MyInfoResponse {
+public class UserInfoResponse {
 
     private final String email;
     private final String name;
@@ -17,8 +17,9 @@ public class MyInfoResponse {
     private final String major;
     private final BigDecimal previousGpa;
     private final Campus campus;
+    private final String introduction;
 
-    public MyInfoResponse(String email, String name, AcademicYear academicYear, String studentNumber, String phoneNumber, String major, BigDecimal previousGpa, Campus campus) {
+    public UserInfoResponse(String email, String name, AcademicYear academicYear, String studentNumber, String phoneNumber, String major, BigDecimal previousGpa, Campus campus, String introduction) {
         this.email = email;
         this.name = name;
         this.academicYear = academicYear;
@@ -27,5 +28,6 @@ public class MyInfoResponse {
         this.major = major;
         this.previousGpa = previousGpa;
         this.campus = campus;
+        this.introduction = introduction;
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/response/UserProfileResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,17 @@
+package com.seungwook.ktsp.domain.user.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UserProfileResponse {
+
+    private final String name;
+    private final String major;
+    private final String studentNumber;
+
+    public UserProfileResponse(String name, String major, String studentNumber) {
+        this.name = name;
+        this.major = major;
+        this.studentNumber = studentNumber;
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/response/UserProfileResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/response/UserProfileResponse.java
@@ -8,10 +8,12 @@ public class UserProfileResponse {
     private final String name;
     private final String major;
     private final String studentNumber;
+    private final String introduction;
 
-    public UserProfileResponse(String name, String major, String studentNumber) {
+    public UserProfileResponse(String name, String major, String studentNumber, String introduction) {
         this.name = name;
         this.major = major;
         this.studentNumber = studentNumber;
+        this.introduction = introduction;
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/entity/User.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/entity/User.java
@@ -25,7 +25,7 @@ public class User extends BaseEntity {
     @Column(name = "email", nullable = false, unique = true, length = 40)
     private String email;
 
-    @Column(name = "phone_number", nullable = false, unique = true, length = 13)
+    @Column(name = "phone_number", nullable = false, unique = true, columnDefinition = "CHAR(13)")
     private String phoneNumber;
 
     @Column(name = "password", nullable = false, length = 60)
@@ -34,7 +34,7 @@ public class User extends BaseEntity {
     @Column(name = "name", nullable = false, length = 15)
     private String name;
 
-    @Column(name = "student_number", unique = true, length = 9)
+    @Column(name = "student_number", unique = true, columnDefinition = "CHAR(9)")
     private String studentNumber;
 
     @Enumerated(EnumType.STRING)
@@ -50,6 +50,9 @@ public class User extends BaseEntity {
 
     @Column(name = "previous_gpa", precision = 3, scale = 2, nullable = false)
     private BigDecimal previousGpa;
+
+    @Column(name = "introduction", nullable = true, length = 255)
+    private String introduction;
 
     @Column(name = "activated", nullable = false)
     private Boolean activated;
@@ -69,6 +72,7 @@ public class User extends BaseEntity {
         this.campus = campus;
         this.major = major;
         this.previousGpa = previousGpa;
+        this.introduction = null;
         this.activated = true;
         this.role = role;
     }
@@ -110,13 +114,14 @@ public class User extends BaseEntity {
         this.password = encodedPassword;
     }
 
-    // 학년 변경
-    public void changeUserInformation(AcademicYear newYear, String newPhoneNumber, String newMajor, BigDecimal newGpa, Campus newCampus) {
+    // 회원 정보 변경
+    public void changeUserInformation(AcademicYear newYear, String newPhoneNumber, String newMajor, BigDecimal newGpa, Campus newCampus, String introduction) {
         this.academicYear = newYear;
         this.phoneNumber = newPhoneNumber;
         this.major = newMajor;
         this.previousGpa = newGpa;
         this.campus = newCampus;
+        this.introduction = introduction;
     }
 
     // 계정 비활성화

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
@@ -8,7 +8,8 @@ public class UserResponseMapper {
 
     // UserInfoResponse로 변환
     public static UserInfoResponse toUserInfoResponse(User user) {
-        return new UserInfoResponse(user.getEmail(),
+        return new UserInfoResponse(
+                user.getEmail(),
                 user.getName(),
                 user.getAcademicYear(),
                 user.getStudentNumber(),
@@ -22,9 +23,11 @@ public class UserResponseMapper {
 
     // UserProfileResponse로 변환
     public static UserProfileResponse toUserProfileResponse(User user) {
-        return new UserProfileResponse(user.getName(),
+        return new UserProfileResponse(
+                user.getName(),
                 user.getMajor(),
-                user.getStudentNumber().substring(2, 4) + "학번"
+                user.getStudentNumber().substring(2, 4) + "학번",
+                user.getIntroduction()
         );
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
@@ -1,11 +1,12 @@
 package com.seungwook.ktsp.domain.user.mapper;
 
 import com.seungwook.ktsp.domain.user.dto.response.UserInfoResponse;
+import com.seungwook.ktsp.domain.user.dto.response.UserProfileResponse;
 import com.seungwook.ktsp.domain.user.entity.User;
 
 public class UserResponseMapper {
 
-    // MyInfoResponse로 변환
+    // UserInfoResponse로 변환
     public static UserInfoResponse toUserInfoResponse(User user) {
         return new UserInfoResponse(user.getEmail(),
                 user.getName(),
@@ -15,6 +16,15 @@ public class UserResponseMapper {
                 user.getPhoneNumber(),
                 user.getPreviousGpa(),
                 user.getCampus(),
-                user.getIntroduction());
+                user.getIntroduction()
+        );
+    }
+
+    // UserProfileResponse로 변환
+    public static UserProfileResponse toUserProfileResponse(User user) {
+        return new UserProfileResponse(user.getName(),
+                user.getMajor(),
+                user.getStudentNumber().substring(2, 4) + "학번"
+        );
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
@@ -1,19 +1,20 @@
 package com.seungwook.ktsp.domain.user.mapper;
 
-import com.seungwook.ktsp.domain.user.dto.response.MyInfoResponse;
+import com.seungwook.ktsp.domain.user.dto.response.UserInfoResponse;
 import com.seungwook.ktsp.domain.user.entity.User;
 
 public class UserResponseMapper {
 
     // MyInfoResponse로 변환
-    public static MyInfoResponse toMyinfoResponse(User user) {
-        return new MyInfoResponse(user.getEmail(),
+    public static UserInfoResponse toUserInfoResponse(User user) {
+        return new UserInfoResponse(user.getEmail(),
                 user.getName(),
                 user.getAcademicYear(),
                 user.getStudentNumber(),
                 user.getPhoneNumber(),
-                user.getMajor(),
+                user.getPhoneNumber(),
                 user.getPreviousGpa(),
-                user.getCampus());
+                user.getCampus(),
+                user.getIntroduction());
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/mapper/UserResponseMapper.java
@@ -14,7 +14,7 @@ public class UserResponseMapper {
                 user.getAcademicYear(),
                 user.getStudentNumber(),
                 user.getPhoneNumber(),
-                user.getPhoneNumber(),
+                user.getMajor(),
                 user.getPreviousGpa(),
                 user.getCampus(),
                 user.getIntroduction()

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.seungwook.ktsp.domain.user.service;
 
-import com.seungwook.ktsp.domain.user.dto.request.MyInfoUpdateRequest;
+import com.seungwook.ktsp.domain.user.dto.request.UserInfoUpdateRequest;
+import com.seungwook.ktsp.domain.user.dto.request.PasswordUpdateRequest;
 import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.exception.UserUpdateFailedException;
 import com.seungwook.ktsp.domain.user.exception.UserNotFoundException;
@@ -28,7 +29,7 @@ public class UserService {
 
     // 내 정보 수정
     @Transactional
-    public User updateUserInformation(long userId, MyInfoUpdateRequest request) {
+    public User updateUserInformation(long userId, UserInfoUpdateRequest request) {
         User user = findById(userId);
 
         String newPhoneNumber = request.getPhoneNumber();
@@ -42,7 +43,8 @@ public class UserService {
                 request.getPhoneNumber(),
                 request.getMajor(),
                 request.getPreviousGpa(),
-                request.getCampus());
+                request.getCampus(),
+                request.getIntroduction());
 
         log.info("회원정보 변경 성공 - userId: {}", user.getId());
 
@@ -51,11 +53,15 @@ public class UserService {
 
     // 비밀번호 변경
     @Transactional
-    public void updatePassword(long userId, String password){
+    public void updatePassword(long userId, PasswordUpdateRequest request){
         User user = findById(userId);
 
+        if (!passwordEncoder.matches(request.getOldPassword(), user.getPassword())) {
+            throw new UserUpdateFailedException(HttpStatus.UNAUTHORIZED, "기존 비밀번호가 일치하지 않습니다.");
+        }
+
         // 암호화 저장
-        user.changePassword(passwordEncoder.encode(password));
+        user.changePassword(passwordEncoder.encode(request.getNewPassword()));
 
         log.info("비밀번호 변경 성공 - userId: {}", user.getId());
     }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/AccountController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/AccountController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Account", description = "회원가입, 로그인, 로그아웃 API")
+@Tag(name = "Account", description = "회원가입, 로그인, 로그아웃, 비밀번호 찾기 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/account")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/EmailService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/EmailService.java
@@ -63,7 +63,7 @@ public class EmailService {
         return mailTemplateEngine.process("auth_code", context);
     }
 
-    // 회원가입용 이메일 폼 생성
+    // 보안코드 발송 이메일 폼 생성
     private MimeMessage createEmailForm(String email, String authCode) throws MessagingException {
         MimeMessage message = javaMailSender.createMimeMessage();
 


### PR DESCRIPTION
## 연관된 이슈
#13 User 엔티티에 자기소개 필드, 유저 프로필 조회 엔드포인트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 자기소개(introduction) 항목이 추가되어, 회원정보에 자기소개를 입력 및 조회할 수 있습니다.
  * 특정 사용자의 프로필(이름, 학과, 학번, 자기소개) 조회 API가 추가되었습니다.

* **기능 개선**
  * 비밀번호 변경 시 기존 비밀번호와 새 비밀번호를 모두 입력하도록 개선되어, 보안이 강화되었습니다.
  * 회원정보 수정 시 자기소개 항목도 함께 수정할 수 있습니다.

* **문서화**
  * 사용자 관련 API에 대한 Swagger/OpenAPI 문서가 보강되었습니다.

* **버그 수정**
  * 없음

* **기타**
  * 일부 API 경로 및 반환 데이터 구조가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->