### PR TITLE
Feat/user 회원 탈퇴 기능 구현

### DIFF
--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserCommandController.java
@@ -2,7 +2,7 @@ package com.seungwook.ktsp.domain.user.controller;
 
 import com.seungwook.ktsp.domain.user.dto.request.PasswordUpdateRequest;
 import com.seungwook.ktsp.domain.user.dto.request.UserInfoUpdateRequest;
-import com.seungwook.ktsp.domain.user.dto.request.WithDrawnRequest;
+import com.seungwook.ktsp.domain.user.dto.request.WithdrawnRequest;
 import com.seungwook.ktsp.domain.user.dto.response.UserInfoResponse;
 import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.mapper.UserResponseMapper;
@@ -58,12 +58,12 @@ public class UserCommandController {
     // 회원 탈퇴
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴, 자동 로그인 상태에선 요청 거부")
     @DeleteMapping
-    public ResponseEntity<Response<Void>> withDrawnUser(@AuthenticationPrincipal UserSession userSession,
-                                                        @Valid @RequestBody WithDrawnRequest request,
+    public ResponseEntity<Response<Void>> withdrawnUser(@AuthenticationPrincipal UserSession userSession,
+                                                        @Valid @RequestBody WithdrawnRequest request,
                                                         HttpServletRequest httpRequest,
                                                         HttpServletResponse httpResponse) {
 
-        userService.withDrawnUser(userSession, request, httpRequest, httpResponse);
+        userService.withdrawnUser(userSession, request, httpRequest, httpResponse);
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("탈퇴가 완료되었습니다.")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserCommandController.java
@@ -2,21 +2,23 @@ package com.seungwook.ktsp.domain.user.controller;
 
 import com.seungwook.ktsp.domain.user.dto.request.PasswordUpdateRequest;
 import com.seungwook.ktsp.domain.user.dto.request.UserInfoUpdateRequest;
+import com.seungwook.ktsp.domain.user.dto.request.WithDrawnRequest;
 import com.seungwook.ktsp.domain.user.dto.response.UserInfoResponse;
 import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.mapper.UserResponseMapper;
 import com.seungwook.ktsp.domain.user.service.UserService;
+import com.seungwook.ktsp.global.auth.dto.UserSession;
 import com.seungwook.ktsp.global.auth.service.AuthService;
 import com.seungwook.ktsp.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User Command", description = "회원 정보 수정 API")
 @RestController
@@ -50,6 +52,21 @@ public class UserCommandController {
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("비밀번호가 변경되었습니다.")
+                .build());
+    }
+
+    // 회원 탈퇴
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴, 자동 로그인 상태에선 요청 거부")
+    @DeleteMapping
+    public ResponseEntity<Response<Void>> withDrawnUser(@AuthenticationPrincipal UserSession userSession,
+                                                        @Valid @RequestBody WithDrawnRequest request,
+                                                        HttpServletRequest httpRequest,
+                                                        HttpServletResponse httpResponse) {
+
+        userService.withDrawnUser(userSession, request, httpRequest, httpResponse);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("탈퇴가 완료되었습니다.")
                 .build());
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/WithDrawnRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/WithDrawnRequest.java
@@ -1,0 +1,19 @@
+package com.seungwook.ktsp.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class WithDrawnRequest {
+
+    @Schema(description = "사용자 비밀번호", example = "SecurePass123!")
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 ~ 최대 30자 입니다.")
+    private final String password;
+
+    public WithDrawnRequest(String password) {
+        this.password = password;
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/WithdrawnRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/dto/request/WithdrawnRequest.java
@@ -6,14 +6,14 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
-public class WithDrawnRequest {
+public class WithdrawnRequest {
 
     @Schema(description = "사용자 비밀번호", example = "SecurePass123!")
     @NotBlank(message = "비밀번호는 필수 항목입니다.")
     @Size(min = 8, max = 30, message = "비밀번호는 최소 8자 ~ 최대 30자 입니다.")
     private final String password;
 
-    public WithDrawnRequest(String password) {
+    public WithdrawnRequest(String password) {
         this.password = password;
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/entity/enums/UserStatus.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/entity/enums/UserStatus.java
@@ -1,0 +1,5 @@
+package com.seungwook.ktsp.domain.user.entity.enums;
+
+public enum UserStatus {
+    ACTIVE, SUSPENDED, WITHDRAWN
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/exception/PasswordMismatchException.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/exception/PasswordMismatchException.java
@@ -1,0 +1,10 @@
+package com.seungwook.ktsp.domain.user.exception;
+
+import com.seungwook.ktsp.global.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class PasswordMismatchException extends BaseCustomException {
+    public PasswordMismatchException() {
+        super(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/exception/RememberMeAccessDeniedException.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/exception/RememberMeAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.seungwook.ktsp.domain.user.exception;
+
+import com.seungwook.ktsp.global.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+public class RememberMeAccessDeniedException extends BaseCustomException {
+    public RememberMeAccessDeniedException() {
+        super(HttpStatus.FORBIDDEN, "자동 로그인 상태에서는 해당 요청이 허용되지 않습니다.");
+    }
+}
+

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserService.java
@@ -2,7 +2,7 @@ package com.seungwook.ktsp.domain.user.service;
 
 import com.seungwook.ktsp.domain.user.dto.request.UserInfoUpdateRequest;
 import com.seungwook.ktsp.domain.user.dto.request.PasswordUpdateRequest;
-import com.seungwook.ktsp.domain.user.dto.request.WithDrawnRequest;
+import com.seungwook.ktsp.domain.user.dto.request.WithdrawnRequest;
 import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.exception.PasswordMismatchException;
 import com.seungwook.ktsp.domain.user.exception.RememberMeAccessDeniedException;
@@ -77,7 +77,7 @@ public class UserService {
 
     // 회원 탈퇴
     @Transactional
-    public void withDrawnUser(UserSession userSession, WithDrawnRequest request, HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
+    public void withdrawnUser(UserSession userSession, WithdrawnRequest request, HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
 
         // 자동 로그인 상태에선 요청 거절
         if(userSession.isRememberMe()) throw new RememberMeAccessDeniedException();

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/filter/RememberMeAuthenticationFilter.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/filter/RememberMeAuthenticationFilter.java
@@ -44,7 +44,7 @@ public class RememberMeAuthenticationFilter extends OncePerRequestFilter {
                 if (userId != null) {
                     // userId DB 조회, 계정이 활성 상태인지 확인
                     userRepository.findById(userId)
-                            .filter(User::getActivated)
+                            .filter(User::isActive)
                             .ifPresent(user -> {
 
                                 // 기존 세션이 존재하면 무효화

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.seungwook.ktsp.global.auth.service;
 
 import com.seungwook.ktsp.domain.user.entity.User;
+import com.seungwook.ktsp.domain.user.entity.enums.UserStatus;
 import com.seungwook.ktsp.domain.user.repository.UserRepository;
 import com.seungwook.ktsp.global.auth.dto.UserSession;
 import com.seungwook.ktsp.global.auth.dto.request.LoginRequest;
@@ -113,7 +114,7 @@ public class AuthService {
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) throw new LoginFailedException();
 
-        if (!user.getActivated()) {
+        if (!user.isActive()) {
             log.warn("비활성 회원 로그인 시도 차단 - userId: {}", user.getId());
             throw new LoginFailedException("정지된 계정입니다. 관리자에게 문의바랍니다.");
         }


### PR DESCRIPTION
## 연관된 이슈
#17 회원 탈퇴 기능

## 작업 내용
- `@SQLDelete`, `@SQLRestriction` 를 통해서 회원 탈퇴 요청시 soft delete 되도록 구현
- UserStatus 를 통해서 User의 상태를 Enum으로 관리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원 탈퇴(계정 삭제) API가 추가되어 사용자가 직접 계정을 탈퇴할 수 있습니다.
  * 회원 상태를 관리하는 새로운 상태값(활성, 정지, 탈퇴) 시스템이 도입되었습니다.

* **버그 수정**
  * 자동 로그인(remember me) 상태에서는 회원 탈퇴 요청이 거부됩니다.
  * 비밀번호 불일치 시 명확한 에러 메시지가 제공됩니다.

* **기타**
  * 회원 탈퇴 시 실제 데이터 삭제 대신 소프트 딜리트(상태값 변경) 방식이 적용되었습니다.
  * API 문서에 회원 탈퇴 관련 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->