### PR TITLE
Feat/user: 패키지 구조 변경 및 UserRepository 단일 진입점 구현

### DIFF
--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/PreAuthAccountController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/PreAuthAccountController.java
@@ -1,0 +1,52 @@
+package com.seungwook.ktsp.domain.user.controller;
+
+import com.seungwook.ktsp.global.auth.dto.request.PasswordResetRequest;
+import com.seungwook.ktsp.global.auth.dto.request.RegisterRequest;
+import com.seungwook.ktsp.domain.user.service.PreAuthAccountService;
+import com.seungwook.ktsp.global.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/public/user")
+public class PreAuthAccountController {
+
+    private final PreAuthAccountService preAuthAccountService;
+
+    // 회원가입
+    @Operation(summary = "회원가입", description = "이메일 인증을 완료한 사용자 회원가입")
+    @PreAuthorize("!isAuthenticated()") // 이미 인증된 상태라면 거부
+    @PostMapping
+    public ResponseEntity<Response<Void>> register(@Valid @RequestBody RegisterRequest request, HttpServletRequest httpRequest) {
+
+        preAuthAccountService.register(request, httpRequest);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("회원가입 성공")
+                .build());
+    }
+
+    // 비밀번호 찾기
+    @Operation(summary = "비밀번호 찾기", description = "이메일 인증을 완료한 사용자 비밀번호 변경 가능")
+    @PreAuthorize("!isAuthenticated()") // 이미 인증된 상태라면 거부
+    @PostMapping("/find-password")
+    public ResponseEntity<Response<Void>> findPassword(@Valid @RequestBody PasswordResetRequest request, HttpServletRequest httpServletRequest) {
+
+        preAuthAccountService.resetPassword(request, httpServletRequest);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("비밀번호 변경 성공")
+                .build());
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserCommandController.java
@@ -20,7 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "User Command", description = "회원 정보 수정 API")
+@Tag(name = "User")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/service/user")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/controller/UserQueryController.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "User Query", description = "회원 정보 조회 API (내 정보 및 타인 프로필)")
+@Tag(name = "User")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/service/user")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
@@ -1,13 +1,14 @@
 package com.seungwook.ktsp.domain.user.repository;
 
 import com.seungwook.ktsp.domain.user.entity.User;
+import com.seungwook.ktsp.domain.user.repository.querydsl.UserQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long>, UserQueryRepository{
+public interface UserRepository extends JpaRepository<User, Long>, UserQueryRepository {
 
     boolean existsByEmail(String email);
 
@@ -19,11 +20,11 @@ public interface UserRepository extends JpaRepository<User, Long>, UserQueryRepo
     @Query("SELECT u FROM User u WHERE u.studentNumber = :studentNumber AND u.status <> 'WITHDRAWN'")
     Optional<User> findByStudentNumberExceptWithdrawn(@Param("studentNumber") String studentNumber);
 
-    // email를 바탕으로 탈퇴하지 않은 uer 리턴
+    // email를 바탕으로 탈퇴하지 않은 user 리턴
     @Query("SELECT u FROM User u WHERE u.email = :email AND u.status <> 'WITHDRAWN'")
     Optional<User> findByEmailExceptWithdrawn(@Param("email") String email);
 
-    // userId를 바탕으로 탈퇴하지 않은 User 리턴
-    @Query("SELECT u FROM User u WHERE u.id = :id AND u.status <> 'WITHDRAWN'")
-    Optional<User> findByIdExceptWithdrawn(@Param("id") Long userId);
+    // userId를 바탕으로 Active인 User 조회
+    @Query("SELECT u FROM User u WHERE u.id = :id AND u.status = 'ACTIVE'")
+    Optional<User> findActiveUserById(@Param("id") Long id);
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/UserRepository.java
@@ -27,4 +27,8 @@ public interface UserRepository extends JpaRepository<User, Long>, UserQueryRepo
     // userId를 바탕으로 Active인 User 조회
     @Query("SELECT u FROM User u WHERE u.id = :id AND u.status = 'ACTIVE'")
     Optional<User> findActiveUserById(@Param("id") Long id);
+
+    // userId를 바탕으로 탈퇴하지 않은 User 리턴
+    @Query("SELECT u FROM User u WHERE u.id = :id AND u.status <> 'WITHDRAWN'")
+    Optional<User> findByIdExceptWithdrawn(@Param("id") Long userId);
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/querydsl/UserQueryRepository.java
@@ -1,4 +1,4 @@
-package com.seungwook.ktsp.domain.user.repository;
+package com.seungwook.ktsp.domain.user.repository.querydsl;
 
 import com.seungwook.ktsp.domain.user.dto.UserProfile;
 import org.springframework.data.repository.query.Param;

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/querydsl/UserQueryRepositoryImpl.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/repository/querydsl/UserQueryRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.seungwook.ktsp.domain.user.repository;
+package com.seungwook.ktsp.domain.user.repository.querydsl;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.seungwook.ktsp.domain.user.dto.UserProfile;

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/PreAuthAccountService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/PreAuthAccountService.java
@@ -1,8 +1,6 @@
-package com.seungwook.ktsp.global.auth.service;
+package com.seungwook.ktsp.domain.user.service;
 
 import com.seungwook.ktsp.domain.user.entity.User;
-import com.seungwook.ktsp.domain.user.exception.UserNotFoundException;
-import com.seungwook.ktsp.domain.user.repository.UserRepository;
 import com.seungwook.ktsp.global.auth.dto.request.PasswordResetRequest;
 import com.seungwook.ktsp.global.auth.dto.request.RegisterRequest;
 import com.seungwook.ktsp.global.auth.exception.RegisterFailedException;
@@ -23,9 +21,9 @@ import java.time.Year;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class AccountService {
+public class PreAuthAccountService {
 
-    private final UserRepository userRepository;
+    private final UserDomainService userDomainService;
     private final PasswordEncoder passwordEncoder;
     private final AuthCodeRedisService authCodeRedisService;
 
@@ -47,7 +45,7 @@ public class AccountService {
 
         // 유저 생성 및 저장
         User newUser = createUser(request);
-        userRepository.save(newUser);
+        userDomainService.save(newUser);
 
         // 인증 완료 이메일 제거
         deleteVerifiedEmailFromRedis(request.getEmail());
@@ -66,8 +64,7 @@ public class AccountService {
         isVerifyEmail(request.getEmail());
 
         // 회원 조회
-        User user = userRepository.findByEmailExceptWithdrawn(request.getEmail())
-                .orElseThrow(UserNotFoundException::new);
+        User user = userDomainService.findByEmailExceptWithdrawn(request.getEmail());
 
         // 비밀번호 변경
         user.changePassword(passwordEncoder.encode(request.getPassword()));
@@ -87,9 +84,9 @@ public class AccountService {
 
     // 이메일, 학번, 전화번호 중복 검사
     private void validateDuplicate(String email, String studentNumber, String phoneNumber) {
-        if (userRepository.existsByEmail(email)) throw new RegisterFailedException("이미 등록된 이메일입니다.");
-        if(userRepository.existsByStudentNumber(studentNumber)) throw new RegisterFailedException("이미 등록된 학번입니다.");
-        if(userRepository.existsByPhoneNumber(phoneNumber)) throw new RegisterFailedException("이미 등록된 전화번호입니다.");
+        if (userDomainService.existsByEmail(email)) throw new RegisterFailedException("이미 등록된 이메일입니다.");
+        if(userDomainService.existsByStudentNumber(studentNumber)) throw new RegisterFailedException("이미 등록된 학번입니다.");
+        if(userDomainService.existsByPhoneNumber(phoneNumber)) throw new RegisterFailedException("이미 등록된 전화번호입니다.");
     }
 
     // User 객체 생성

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserCommandService.java
@@ -90,8 +90,8 @@ public class UserCommandService {
         log.info("회원 탈퇴 완료: {}({})", userId, IpUtil.getClientIP(httpRequest));
     }
 
-    // 탈퇴하지 않은 회원 조회
+    // 활성화된 회원 조회
     private User findById(long userId) {
-        return userDomainService.findByIdExceptWithdrawn(userId);
+        return userDomainService.findActiveUserById(userId);
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserDomainService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserDomainService.java
@@ -1,0 +1,75 @@
+package com.seungwook.ktsp.domain.user.service;
+
+import com.seungwook.ktsp.domain.user.dto.UserProfile;
+import com.seungwook.ktsp.domain.user.entity.User;
+import com.seungwook.ktsp.domain.user.exception.UserNotFoundException;
+import com.seungwook.ktsp.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserDomainService {
+
+    private final UserRepository userRepository;
+
+    // User 저장
+    @Transactional
+    public void save(User user) {
+        userRepository.save(user);
+    }
+
+    // User 삭제
+    @Transactional
+    public void delete(User user) {
+        userRepository.delete(user);
+    }
+
+    //
+    @Transactional(readOnly = true)
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByStudentNumber(String studentNumber) {
+        return userRepository.existsByStudentNumber(studentNumber);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByPhoneNumber(String phoneNumber) {
+        return userRepository.existsByPhoneNumber(phoneNumber);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<User> findByStudentNumberExceptWithdrawn(String studentNumber) {
+        return userRepository.findByStudentNumberExceptWithdrawn(studentNumber);
+    }
+
+    @Transactional(readOnly = true)
+    public User findByEmailExceptWithdrawn(String email) {
+        return userRepository.findByEmailExceptWithdrawn(email)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public User findByIdExceptWithdrawn(Long userId) {
+        return userRepository.findByIdExceptWithdrawn(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfile findUserProfileById(Long userId) {
+        return userRepository.findUserProfileById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<User> findActiveById(Long userId) {
+        return userRepository.findByIdExceptWithdrawn(userId)
+                .filter(User::isActive);
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserDomainService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserDomainService.java
@@ -28,48 +28,54 @@ public class UserDomainService {
         userRepository.delete(user);
     }
 
-    //
+    // 이미 등록된 이메일인지 검사
     @Transactional(readOnly = true)
     public boolean existsByEmail(String email) {
         return userRepository.existsByEmail(email);
     }
 
+    // 이미 등록된 학번인지 검사
     @Transactional(readOnly = true)
     public boolean existsByStudentNumber(String studentNumber) {
         return userRepository.existsByStudentNumber(studentNumber);
     }
 
+    // 이미 등록된 전화번호인지 검사
     @Transactional(readOnly = true)
     public boolean existsByPhoneNumber(String phoneNumber) {
         return userRepository.existsByPhoneNumber(phoneNumber);
     }
 
+    // 학번을 기준으로 탈퇴하지 않은 User 리턴
     @Transactional(readOnly = true)
     public Optional<User> findByStudentNumberExceptWithdrawn(String studentNumber) {
         return userRepository.findByStudentNumberExceptWithdrawn(studentNumber);
     }
 
+    // 이메일을 기준으로 탈퇴하지 않은 User 리턴
     @Transactional(readOnly = true)
     public User findByEmailExceptWithdrawn(String email) {
         return userRepository.findByEmailExceptWithdrawn(email)
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    // userId를 바탕으로 User 리턴
     @Transactional(readOnly = true)
-    public User findByIdExceptWithdrawn(Long userId) {
-        return userRepository.findByIdExceptWithdrawn(userId)
+    public User findActiveUserById(Long userId) {
+        return userRepository.findActiveUserById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    // userId를 바탕으로 Optional<User> 리턴
+    @Transactional(readOnly = true)
+    public Optional<User> findActiveById(Long userId) {
+        return userRepository.findActiveUserById(userId);
+    }
+
+    // userId를 바탕으로 UserProfile 리턴
     @Transactional(readOnly = true)
     public UserProfile findUserProfileById(Long userId) {
         return userRepository.findUserProfileById(userId)
                 .orElseThrow(UserNotFoundException::new);
-    }
-
-    @Transactional(readOnly = true)
-    public Optional<User> findActiveById(Long userId) {
-        return userRepository.findByIdExceptWithdrawn(userId)
-                .filter(User::isActive);
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserDomainService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserDomainService.java
@@ -59,7 +59,7 @@ public class UserDomainService {
                 .orElseThrow(UserNotFoundException::new);
     }
 
-    // userId를 바탕으로 User 리턴
+    // userId를 바탕으로 활성화된 User 리턴
     @Transactional(readOnly = true)
     public User findActiveUserById(Long userId) {
         return userRepository.findActiveUserById(userId)
@@ -70,6 +70,12 @@ public class UserDomainService {
     @Transactional(readOnly = true)
     public Optional<User> findActiveById(Long userId) {
         return userRepository.findActiveUserById(userId);
+    }
+
+    // userId를 바탕으로 탈퇴하지 않은 User 리턴
+    public User findByIdExceptWithdrawn(long userId) {
+        return userRepository.findByIdExceptWithdrawn(userId)
+                .orElseThrow(UserNotFoundException::new);
     }
 
     // userId를 바탕으로 UserProfile 리턴

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserQueryService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserQueryService.java
@@ -26,7 +26,8 @@ public class UserQueryService {
         return userDomainService.findUserProfileById(userId);
     }
 
+    // 활성화된 회원 조회
     private User findById(long userId) {
-        return userDomainService.findByIdExceptWithdrawn(userId);
+        return userDomainService.findActiveUserById(userId);
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserQueryService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserQueryService.java
@@ -2,8 +2,6 @@ package com.seungwook.ktsp.domain.user.service;
 
 import com.seungwook.ktsp.domain.user.dto.UserProfile;
 import com.seungwook.ktsp.domain.user.entity.User;
-import com.seungwook.ktsp.domain.user.exception.UserNotFoundException;
-import com.seungwook.ktsp.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserQueryService {
 
-    private final UserRepository userRepository;
+    private final UserDomainService userDomainService;
 
     // 내 정보 조회
     @Transactional(readOnly = true)
@@ -25,12 +23,10 @@ public class UserQueryService {
     // 사용자 프로필 조회
     @Transactional(readOnly = true)
     public UserProfile getUserProfile(long userId) {
-        return userRepository.findUserProfileById(userId)
-                .orElseThrow(UserNotFoundException::new);
+        return userDomainService.findUserProfileById(userId);
     }
 
     private User findById(long userId) {
-        return userRepository.findByIdExceptWithdrawn(userId)
-                .orElseThrow(UserNotFoundException::new);
+        return userDomainService.findByIdExceptWithdrawn(userId);
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/config/SecurityConfig.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.seungwook.ktsp.global.auth.config;
 
-import com.seungwook.ktsp.domain.user.repository.UserRepository;
+import com.seungwook.ktsp.domain.user.service.UserDomainService;
 import com.seungwook.ktsp.global.auth.filter.RememberMeAuthenticationFilter;
 import com.seungwook.ktsp.global.auth.service.RememberMeTokenService;
 import com.seungwook.ktsp.global.auth.support.SessionSecuritySupport;
@@ -39,7 +39,7 @@ public class SecurityConfig {
     private final AccessDeniedHandler accessDeniedHandler;
     private final RememberMeTokenService rememberMeTokenService;
     private final SessionSecuritySupport sessionSecuritySupport;
-    private final UserRepository userRepository;
+    private final UserDomainService userDomainService;
 
     @Value("${spring.profiles.active}")
     private String activeProfile;
@@ -60,13 +60,12 @@ public class SecurityConfig {
                         .sessionRegistry(registry) // SessionRegistry 연동
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/public/**", "/account/**", "/verify/**",
-                                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**").permitAll()
+                        .requestMatchers("/public/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**").permitAll()
                         .requestMatchers("/service/**").hasAnyRole("USER", "ADMIN")
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new RememberMeAuthenticationFilter(rememberMeTokenService, userRepository, sessionSecuritySupport), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new RememberMeAuthenticationFilter(rememberMeTokenService, userDomainService, sessionSecuritySupport), UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(authenticationEntryPoint) // 인증 실패
                         .accessDeniedHandler(accessDeniedHandler) // 권한 부족

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/AuthController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/AuthController.java
@@ -1,10 +1,7 @@
 package com.seungwook.ktsp.global.auth.controller;
 
 import com.seungwook.ktsp.global.auth.dto.request.LoginRequest;
-import com.seungwook.ktsp.global.auth.dto.request.PasswordResetRequest;
-import com.seungwook.ktsp.global.auth.dto.request.RegisterRequest;
 import com.seungwook.ktsp.global.auth.dto.response.LoginResponse;
-import com.seungwook.ktsp.global.auth.service.AccountService;
 import com.seungwook.ktsp.global.auth.service.AuthService;
 import com.seungwook.ktsp.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,27 +17,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Account", description = "회원가입, 로그인, 로그아웃, 비밀번호 찾기 API")
+@Tag(name = "Auth", description = "로그인, 로그아웃 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/account")
-public class AccountController {
+@RequestMapping("/public/auth")
+public class AuthController {
 
-    private final AccountService accountService;
     private final AuthService authService;
-
-    // 회원가입
-    @Operation(summary = "회원가입", description = "이메일 인증을 완료한 사용자 회원가입")
-    @PreAuthorize("!isAuthenticated()") // 이미 인증된 상태라면 거부
-    @PostMapping("/register")
-    public ResponseEntity<Response<Void>> register(@Valid @RequestBody RegisterRequest request, HttpServletRequest httpRequest) {
-
-        accountService.register(request, httpRequest);
-
-        return ResponseEntity.ok(Response.<Void>builder()
-                .message("회원가입 성공")
-                .build());
-    }
 
     // 로그인
     @Operation(summary = "로그인", description = "학번과 비밀번호를 통해 로그인, 세션 기반 인증 수행")
@@ -53,19 +36,6 @@ public class AccountController {
         return ResponseEntity.ok(Response.<LoginResponse>builder()
                 .message("로그인 성공")
                 .data(response)
-                .build());
-    }
-
-    // 비밀번호 찾기
-    @Operation(summary = "비밀번호 찾기", description = "이메일 인증을 완료한 사용자 비밀번호 변경 가능")
-    @PreAuthorize("!isAuthenticated()") // 이미 인증된 상태라면 거부
-    @PostMapping("/find-password")
-    public ResponseEntity<Response<Void>> findPassword(@Valid @RequestBody PasswordResetRequest request, HttpServletRequest httpServletRequest) {
-
-        accountService.resetPassword(request, httpServletRequest);
-
-        return ResponseEntity.ok(Response.<Void>builder()
-                .message("비밀번호 변경 성공")
                 .build());
     }
 

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/EmailVerifyController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/controller/EmailVerifyController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Email Verification", description = "이메일 인증 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/verify")
+@RequestMapping("/public/email")
 public class EmailVerifyController {
 
     private final VerificationService verificationService;
@@ -41,7 +41,7 @@ public class EmailVerifyController {
 
     // 인증코드 검증
     @Operation(summary = "이메일 인증코드 검증", description = "인증코드가 유효한지 검증")
-    @PostMapping
+    @PostMapping("/verify")
     public ResponseEntity<Response<Void>> verify(@Valid @RequestBody VerifyRequest request) {
 
         verificationService.verifyAuthCode(request.getEmail(), request.getVerifyCode().toUpperCase());

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/filter/RememberMeAuthenticationFilter.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/filter/RememberMeAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.seungwook.ktsp.global.auth.filter;
 
-import com.seungwook.ktsp.domain.user.entity.User;
-import com.seungwook.ktsp.domain.user.repository.UserRepository;
+import com.seungwook.ktsp.domain.user.service.UserDomainService;
 import com.seungwook.ktsp.global.auth.dto.UserSession;
 import com.seungwook.ktsp.global.auth.service.RememberMeTokenService;
 import com.seungwook.ktsp.global.auth.support.SessionSecuritySupport;
@@ -25,7 +24,7 @@ import java.io.IOException;
 public class RememberMeAuthenticationFilter extends OncePerRequestFilter {
 
     private final RememberMeTokenService tokenService;
-    private final UserRepository userRepository;
+    private final UserDomainService userDomainService;
     private final SessionSecuritySupport sessionSecuritySupport;
 
     @Override
@@ -43,8 +42,7 @@ public class RememberMeAuthenticationFilter extends OncePerRequestFilter {
 
                 if (userId != null) {
                     // userId DB 조회, 계정이 활성 상태인지 확인
-                    userRepository.findByIdExceptWithdrawn(userId)
-                            .filter(User::isActive)
+                    userDomainService.findActiveById(userId)
                             .ifPresent(user -> {
 
                                 // 기존 세션이 존재하면 무효화
@@ -74,12 +72,13 @@ public class RememberMeAuthenticationFilter extends OncePerRequestFilter {
 
     // REMEMBER_ME 쿠키에서 토큰을 추출
     private String extractTokenFromCookie(HttpServletRequest request) {
+
         if (request.getCookies() == null) return null;
-        for (Cookie cookie : request.getCookies()) {
-            if ("REMEMBER_ME".equals(cookie.getName())) {
+
+        for (Cookie cookie : request.getCookies())
+            if ("REMEMBER_ME".equals(cookie.getName()))
                 return cookie.getValue();
-            }
-        }
+
         return null;
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.seungwook.ktsp.global.auth.service;
 
 import com.seungwook.ktsp.domain.user.entity.User;
-import com.seungwook.ktsp.domain.user.repository.UserRepository;
+import com.seungwook.ktsp.domain.user.service.UserDomainService;
 import com.seungwook.ktsp.global.auth.dto.UserSession;
 import com.seungwook.ktsp.global.auth.dto.request.LoginRequest;
 import com.seungwook.ktsp.global.auth.dto.response.LoginResponse;
@@ -34,7 +34,7 @@ public class AuthService {
 
     private static final String REMEMBER_ME_COOKIE = "REMEMBER_ME";
 
-    private final UserRepository userRepository;
+    private final UserDomainService userDomainService;
     private final SessionRegistry sessionRegistry;
     private final PasswordEncoder passwordEncoder;
     private final RememberMeTokenService rememberMeTokenService;
@@ -108,7 +108,7 @@ public class AuthService {
 
     // 사용자 인증 및 계정 활성화 여부 검증
     private User authenticate(LoginRequest request) {
-        User user = userRepository.findByStudentNumberExceptWithdrawn(request.getStudentNumber())
+        User user = userDomainService.findByStudentNumberExceptWithdrawn(request.getStudentNumber())
                 .orElseThrow(LoginFailedException::new);
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) throw new LoginFailedException();

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/global/common/support/UserInitializer.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/global/common/support/UserInitializer.java
@@ -3,11 +3,12 @@ package com.seungwook.ktsp.global.common.support;
 import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.entity.enums.AcademicYear;
 import com.seungwook.ktsp.domain.user.entity.enums.Campus;
-import com.seungwook.ktsp.domain.user.repository.UserRepository;
+import com.seungwook.ktsp.domain.user.service.UserDomainService;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 
@@ -15,7 +16,7 @@ import java.math.BigDecimal;
 @RequiredArgsConstructor
 public class UserInitializer {
 
-    private final UserRepository userRepository;
+    private final UserDomainService userDomainService;
 
     @Value("${spring.profiles.active}")
     private String activeProfile;
@@ -38,13 +39,14 @@ public class UserInitializer {
     @Value("${admin.major}")
     private String major;
 
+    @Transactional
     @PostConstruct
     public void initUser() {
 
         // admin 생성
-        if ((!userRepository.existsByEmail(email)) && (!userRepository.existsByStudentNumber(studentNumber))) {
+        if ((!userDomainService.existsByEmail(email)) && (!userDomainService.existsByStudentNumber(studentNumber))) {
             User admin = User.createAdmin(email, password, studentNumber, name, phoneNumber, major);
-            userRepository.save(admin);
+            userDomainService.save(admin);
         }
 
         // test용 더미 유저
@@ -53,7 +55,7 @@ public class UserInitializer {
             String studentNumber = "201921322";
             String phoneNumber = "010-1234-5679";
 
-            if (!userRepository.existsByEmail(email) && !userRepository.existsByStudentNumber(studentNumber)) {
+            if (!userDomainService.existsByEmail(email) && !userDomainService.existsByStudentNumber(studentNumber)) {
                 User user = User.createUser(email,
                         password,
                         studentNumber,
@@ -63,7 +65,7 @@ public class UserInitializer {
                         phoneNumber,
                         "컴퓨터공학과"
                         , new BigDecimal("3.2"));
-                userRepository.save(user);
+                userDomainService.save(user);
             }
         }
     }


### PR DESCRIPTION
## 연관된 이슈
#23 UserRepository 접근을 UserDomainService로 캡슐화하여 도메인 계층 책임 명확화

## 작업 내용
- 패키지 구조 변경 및 UserRepository 단일 진입점 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증되지 않은 사용자를 위한 회원가입 및 비밀번호 재설정 API가 별도의 컨트롤러로 추가되었습니다.

* **버그 수정**
  * 회원 정보 조회 및 수정 API의 Swagger 문서 태그가 "User"로 통합되어 API 문서가 일관성 있게 개선되었습니다.

* **리팩터링**
  * 사용자 관련 데이터 접근 및 비즈니스 로직이 UserDomainService로 일원화되어 코드 구조와 유지보수성이 개선되었습니다.
  * 일부 엔드포인트의 URL이 /public/user, /public/auth, /public/email 등으로 변경되었습니다.
  * 회원가입과 비밀번호 재설정 기능이 인증 API에서 분리되어 별도의 컨트롤러로 이동되었습니다.

* **기타**
  * 내부 서비스 및 레포지토리 의존성이 정리되고, 보안 설정 및 필터에서 UserDomainService 사용으로 변경되어 유지보수성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->