### PR TITLE
Feat/board

### DIFF
--- a/SpringBoot/build.gradle
+++ b/SpringBoot/build.gradle
@@ -84,8 +84,8 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.21.1'
 
     // S3 or CloudFlare
-    implementation 'software.amazon.awssdk:s3:2.32.7'
-    implementation 'software.amazon.awssdk:apache-client:2.32.7'
+    implementation 'software.amazon.awssdk:s3:2.32.9'
+    implementation 'software.amazon.awssdk:apache-client:2.32.9'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/common/service/BoardFileBindingService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/common/service/BoardFileBindingService.java
@@ -28,10 +28,10 @@ public class BoardFileBindingService {
 
     // 게시글 생성시 연결
     @Transactional
-    public void bindFilesToBoard(Board board, String content, List<String> attachedFiles) {
+    public void bindFilesToBoard(Board board, String content, List<String> files) {
 
-        // attachedFiles이 null인지 검사
-        if (attachedFiles == null || attachedFiles.isEmpty()) return;
+        // Optional로 래핑
+        List<String> attachedFiles = Optional.ofNullable(files).orElse(Collections.emptyList());
 
         // 이미지 + 첨부파일 uuid 통합
         Set<String> requestedUuids = mergeImageAndAttachmentUuids(content, attachedFiles);
@@ -42,13 +42,10 @@ public class BoardFileBindingService {
 
     // 게시글 수정시 연결
     @Transactional
-    public void updateBoundFiles(Board board, String content, List<String> attachedFiles) {
+    public void updateBoundFiles(Board board, String content, List<String> files) {
 
-        // attachedFiles이 null인지 검사
-        if (attachedFiles == null || attachedFiles.isEmpty()) {
-            deleteBoundFiles(board); // 게시글에 관련된 모든 파일 삭제
-            return;
-        }
+        // Optional로 래핑
+        List<String> attachedFiles = Optional.ofNullable(files).orElse(Collections.emptyList());
 
         // 기존 연결된 BoardFile 조회
         List<BoardFile> existingBoardFiles = boardFileDomainService.findByBoard(board);

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/common/service/BoardFileBindingService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/common/service/BoardFileBindingService.java
@@ -12,9 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,6 +30,9 @@ public class BoardFileBindingService {
     @Transactional
     public void bindFilesToBoard(Board board, String content, List<String> attachedFiles) {
 
+        // attachedFiles이 null인지 검사
+        if (attachedFiles == null || attachedFiles.isEmpty()) return;
+
         // 이미지 + 첨부파일 uuid 통합
         Set<String> requestedUuids = mergeImageAndAttachmentUuids(content, attachedFiles);
 
@@ -42,6 +43,12 @@ public class BoardFileBindingService {
     // 게시글 수정시 연결
     @Transactional
     public void updateBoundFiles(Board board, String content, List<String> attachedFiles) {
+
+        // attachedFiles이 null인지 검사
+        if (attachedFiles == null || attachedFiles.isEmpty()) {
+            deleteBoundFiles(board); // 게시글에 관련된 모든 파일 삭제
+            return;
+        }
 
         // 기존 연결된 BoardFile 조회
         List<BoardFile> existingBoardFiles = boardFileDomainService.findByBoard(board);
@@ -69,7 +76,7 @@ public class BoardFileBindingService {
         addFiles(uuidsToAdd, board);
     }
 
-    // 게시글 삭제시 파일 삭제 로직
+    // 특정 게시글에 연결된 모든 파일 삭제 로직
     public void deleteBoundFiles(Board board) {
 
         // 연결된 모든 BoardFile 조회

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/request/CommunityRegisterRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/request/CommunityRegisterRequest.java
@@ -23,5 +23,6 @@ public class CommunityRegisterRequest {
     private final String content;
 
     @Schema(description = "첨부파일 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+    @Size(max = 5, message = "첨부파일은 최대 5개 까지만 업로드 가능합니다.")
     private final List<String> attachedFiles;
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/request/CommunityUpdateRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/request/CommunityUpdateRequest.java
@@ -23,5 +23,6 @@ public class CommunityUpdateRequest {
     private final String content;
 
     @Schema(description = "첨부파일 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+    @Size(max = 5, message = "첨부파일은 최대 5개 까지만 업로드 가능합니다.")
     private final List<String> attachedFiles;
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityListResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityListResponse.java
@@ -1,5 +1,6 @@
-package com.seungwook.ktsp.domain.board.type.community.common.dto;
+package com.seungwook.ktsp.domain.board.type.community.common.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,10 +8,18 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-public class CommunityList {
+public class CommunityListResponse {
+
+    private final int number;
+
     private final long boardId;
+
     private final String title;
+
     private final int hits;
+
     private final String writer;
+
+    @JsonFormat(pattern = "yy.MM.dd")
     private final LocalDateTime createdAt;
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityResponse.java
@@ -32,7 +32,7 @@ public class CommunityResponse {
     @JsonFormat(pattern = "yy.MM.dd-HH:mm:ss")
     private final LocalDateTime modifiedAt;
 
-    private final List<CommentResponse> comments;
-
     private final List<AttachedFileInfo> attachedFiles;
+
+    private final List<CommentResponse> comments;
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/dto/response/CommunityResponse.java
@@ -1,5 +1,6 @@
 package com.seungwook.ktsp.domain.board.type.community.common.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.seungwook.ktsp.domain.board.common.dto.response.Writer;
 import com.seungwook.ktsp.domain.comment.dto.response.CommentResponse;
 import com.seungwook.ktsp.domain.file.dto.AttachedFileInfo;
@@ -14,13 +15,24 @@ import java.util.List;
 public class CommunityResponse {
 
     private final Writer writer;
+
     private final long boardId;
+
     private final int hits;
+
     private final String title;
+
     private final String content;
+
     private final boolean manageable;
+
+    @JsonFormat(pattern = "yy.MM.dd-HH:mm:ss")
     private final LocalDateTime createdAt;
+
+    @JsonFormat(pattern = "yy.MM.dd-HH:mm:ss")
     private final LocalDateTime modifiedAt;
+
     private final List<CommentResponse> comments;
+
     private final List<AttachedFileInfo> attachedFiles;
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
@@ -1,13 +1,44 @@
 package com.seungwook.ktsp.domain.board.type.community.common.mapper;
 
 import com.seungwook.ktsp.domain.board.common.dto.response.Writer;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.response.CommunityListResponse;
 import com.seungwook.ktsp.domain.board.type.community.common.dto.response.CommunityResponse;
 import com.seungwook.ktsp.domain.board.type.community.notice.entity.Notice;
 import com.seungwook.ktsp.domain.file.dto.AttachedFileInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CommunityMapper {
+
+    public static Page<CommunityListResponse> toNoticeList(Page<CommunityList> communityLists) {
+
+        int total = (int) communityLists.getTotalElements(); // 전체 글 수
+        int pageNumber = communityLists.getNumber(); // 현재 페이지 번호 (0부터 시작)
+        int pageSize = communityLists.getSize(); // 페이지당 개수
+
+
+        int startNumber = total - (pageNumber * pageSize);   // 현재 페이지에서 시작할 number
+
+        List<CommunityListResponse> content = new ArrayList<>();
+
+        for (int i = 0; i < communityLists.getContent().size(); i++) {
+            CommunityList dto = communityLists.getContent().get(i);
+            content.add(new CommunityListResponse(
+                    startNumber - i, // 역순
+                    dto.getBoardId(),
+                    dto.getTitle(),
+                    dto.getHits(),
+                    "관리자",
+                    dto.getCreatedAt()
+            ));
+        }
+
+        return new PageImpl<>(content, communityLists.getPageable(), communityLists.getTotalElements());
+    }
 
     public static CommunityResponse toNoticeResponse(Writer writer, Notice notice, List<AttachedFileInfo> attachedFileInfos, boolean manageable) {
         return new CommunityResponse(

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
@@ -6,6 +6,7 @@ import com.seungwook.ktsp.domain.board.type.community.common.dto.response.Commun
 import com.seungwook.ktsp.domain.board.type.community.common.dto.response.CommunityResponse;
 import com.seungwook.ktsp.domain.board.type.community.notice.entity.Notice;
 import com.seungwook.ktsp.domain.board.type.community.report.entity.Report;
+import com.seungwook.ktsp.domain.comment.dto.response.CommentResponse;
 import com.seungwook.ktsp.domain.file.dto.AttachedFileInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -82,7 +83,7 @@ public class CommunityMapper {
         return new PageImpl<>(content, communityLists.getPageable(), communityLists.getTotalElements());
     }
 
-    public static CommunityResponse toReportResponse(Writer writer, Report report, List<AttachedFileInfo> attachedFileInfos, boolean manageable) {
+    public static CommunityResponse toReportResponse(Writer writer, Report report, List<AttachedFileInfo> attachedFileInfos, boolean manageable, List<CommentResponse> comments) {
         return new CommunityResponse(
                 writer,
                 report.getId(),
@@ -92,7 +93,7 @@ public class CommunityMapper {
                 manageable, // 수정 및 삭제 권한 보유 여부
                 report.getCreatedAt(),
                 report.getModifiedAt(),
-                List.of(),
+                comments,
                 attachedFileInfos
         );
     }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
@@ -52,8 +52,8 @@ public class CommunityMapper {
                 manageable, // 수정 및 삭제 권한 보유 여부
                 notice.getCreatedAt(),
                 notice.getModifiedAt(),
-                List.of(), // 공지사항은 댓글 없음
-                attachedFileInfos
+                attachedFileInfos,
+                List.of() // 공지사항은 댓글 없음
         );
     }
 
@@ -93,8 +93,8 @@ public class CommunityMapper {
                 manageable, // 수정 및 삭제 권한 보유 여부
                 report.getCreatedAt(),
                 report.getModifiedAt(),
-                comments,
-                attachedFileInfos
+                attachedFileInfos,
+                comments
         );
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/common/mapper/CommunityMapper.java
@@ -5,6 +5,7 @@ import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
 import com.seungwook.ktsp.domain.board.type.community.common.dto.response.CommunityListResponse;
 import com.seungwook.ktsp.domain.board.type.community.common.dto.response.CommunityResponse;
 import com.seungwook.ktsp.domain.board.type.community.notice.entity.Notice;
+import com.seungwook.ktsp.domain.board.type.community.report.entity.Report;
 import com.seungwook.ktsp.domain.file.dto.AttachedFileInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -51,6 +52,47 @@ public class CommunityMapper {
                 notice.getCreatedAt(),
                 notice.getModifiedAt(),
                 List.of(), // 공지사항은 댓글 없음
+                attachedFileInfos
+        );
+    }
+
+    public static Page<CommunityListResponse> toReportList(Page<CommunityList> communityLists) {
+
+        int total = (int) communityLists.getTotalElements(); // 전체 글 수
+        int pageNumber = communityLists.getNumber(); // 현재 페이지 번호 (0부터 시작)
+        int pageSize = communityLists.getSize(); // 페이지당 개수
+
+
+        int startNumber = total - (pageNumber * pageSize);   // 현재 페이지에서 시작할 number
+
+        List<CommunityListResponse> content = new ArrayList<>();
+
+        for (int i = 0; i < communityLists.getContent().size(); i++) {
+            CommunityList dto = communityLists.getContent().get(i);
+            content.add(new CommunityListResponse(
+                    startNumber - i, // 역순
+                    dto.getBoardId(),
+                    dto.getTitle(),
+                    dto.getHits(),
+                    dto.getWriter(),
+                    dto.getCreatedAt()
+            ));
+        }
+
+        return new PageImpl<>(content, communityLists.getPageable(), communityLists.getTotalElements());
+    }
+
+    public static CommunityResponse toReportResponse(Writer writer, Report report, List<AttachedFileInfo> attachedFileInfos, boolean manageable) {
+        return new CommunityResponse(
+                writer,
+                report.getId(),
+                report.getHits(),
+                report.getTitle(),
+                report.getContent(),
+                manageable, // 수정 및 삭제 권한 보유 여부
+                report.getCreatedAt(),
+                report.getModifiedAt(),
+                List.of(),
                 attachedFileInfos
         );
     }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeCommandController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "공지사항")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/notice")
+@RequestMapping("/admin/board/notice")
 public class NoticeCommandController {
 
     private final NoticeCommandService noticeCommandService;

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeCommandController.java
@@ -2,7 +2,7 @@ package com.seungwook.ktsp.domain.board.type.community.notice.controller;
 
 import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityRegisterRequest;
 import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityUpdateRequest;
-import com.seungwook.ktsp.domain.board.type.community.notice.service.NoticeService;
+import com.seungwook.ktsp.domain.board.type.community.notice.service.NoticeCommandService;
 import com.seungwook.ktsp.global.auth.support.AuthHandler;
 import com.seungwook.ktsp.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,13 +18,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/admin/notice")
 public class NoticeCommandController {
 
-    private final NoticeService noticeService;
+    private final NoticeCommandService noticeCommandService;
 
     @Operation(summary = "공지사항 등록", description = "공지사항은 Admin만 등록 가능")
     @PostMapping
     public ResponseEntity<Response<Void>> registerNotice(@Valid @RequestBody CommunityRegisterRequest request) {
 
-        noticeService.registerNotice(AuthHandler.getUserId(), request);
+        noticeCommandService.registerNotice(AuthHandler.getUserId(), request);
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("공지사항 등록 성공")
@@ -35,7 +35,7 @@ public class NoticeCommandController {
     @PatchMapping("/{boardId}")
     public ResponseEntity<Response<Void>> updateNotice(@PathVariable long boardId, @Valid @RequestBody CommunityUpdateRequest request) {
 
-        noticeService.updateNotice(boardId, request);
+        noticeCommandService.updateNotice(boardId, request);
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("공지사항 수정 성공")
@@ -46,7 +46,7 @@ public class NoticeCommandController {
     @DeleteMapping("/{boardId}")
     public ResponseEntity<Response<Void>> deleteNotice(@PathVariable long boardId) {
 
-        noticeService.deleteNotice(boardId);
+        noticeCommandService.deleteNotice(boardId);
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("공지사항 삭제 성공")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeQueryController.java
@@ -5,7 +5,7 @@ import com.seungwook.ktsp.domain.board.type.community.common.dto.response.Commun
 import com.seungwook.ktsp.domain.board.type.community.common.dto.response.CommunityResponse;
 import com.seungwook.ktsp.domain.board.type.community.common.mapper.CommunityMapper;
 import com.seungwook.ktsp.domain.board.type.community.notice.entity.Notice;
-import com.seungwook.ktsp.domain.board.type.community.notice.service.NoticeService;
+import com.seungwook.ktsp.domain.board.type.community.notice.service.NoticeQueryService;
 import com.seungwook.ktsp.domain.file.dto.AttachedFileInfo;
 import com.seungwook.ktsp.domain.file.service.FileService;
 import com.seungwook.ktsp.domain.user.mapper.UserMapper;
@@ -28,7 +28,7 @@ import java.util.List;
 public class NoticeQueryController {
 
     private final UserQueryService userQueryService;
-    private final NoticeService noticeService;
+    private final NoticeQueryService noticeQueryService;
     private final FileService fileService;
 
     @Operation(summary = "모든 공지사항 조회", description = "모든 공지사항 조회, 페이징 크기 = 15")
@@ -36,7 +36,7 @@ public class NoticeQueryController {
     public ResponseEntity<Response<Page<CommunityListResponse>>> viewNoticeList(@RequestParam(defaultValue = "0") int page) {
 
         // 모든 공지사항 조회
-        Page<CommunityListResponse> response = CommunityMapper.toNoticeList(noticeService.getAllNotice(page));
+        Page<CommunityListResponse> response = CommunityMapper.toNoticeList(noticeQueryService.getAllNotice(page));
 
         return ResponseEntity.ok(Response.<Page<CommunityListResponse>>builder()
                 .message("모든 공지사항 조회 성공")
@@ -49,7 +49,7 @@ public class NoticeQueryController {
     public ResponseEntity<Response<CommunityResponse>> viewNotice(@PathVariable long boardId) {
 
         // 공지사항
-        Notice notice = noticeService.getNotice(boardId);
+        Notice notice = noticeQueryService.getNotice(boardId);
 
         // 작성자
         Writer writer = UserMapper.toWriter(userQueryService.getWriterInfo(notice.getUser().getId()));

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeQueryController.java
@@ -8,7 +8,6 @@ import com.seungwook.ktsp.domain.board.type.community.notice.entity.Notice;
 import com.seungwook.ktsp.domain.board.type.community.notice.service.NoticeQueryService;
 import com.seungwook.ktsp.domain.file.dto.AttachedFileInfo;
 import com.seungwook.ktsp.domain.file.service.FileService;
-import com.seungwook.ktsp.domain.user.mapper.UserMapper;
 import com.seungwook.ktsp.domain.user.service.UserQueryService;
 import com.seungwook.ktsp.global.auth.support.AuthHandler;
 import com.seungwook.ktsp.global.response.Response;
@@ -52,7 +51,7 @@ public class NoticeQueryController {
         Notice notice = noticeQueryService.getNotice(boardId);
 
         // 작성자
-        Writer writer = UserMapper.toWriter(userQueryService.getWriterInfo(notice.getUser().getId()));
+        Writer writer = userQueryService.getWriter(notice.getUser().getId());
 
         // 첨부파일
         List<AttachedFileInfo> attachedFileInfos = fileService.getAttachedFileDownloadPath(boardId);

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/controller/NoticeQueryController.java
@@ -1,7 +1,7 @@
 package com.seungwook.ktsp.domain.board.type.community.notice.controller;
 
 import com.seungwook.ktsp.domain.board.common.dto.response.Writer;
-import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.response.CommunityListResponse;
 import com.seungwook.ktsp.domain.board.type.community.common.dto.response.CommunityResponse;
 import com.seungwook.ktsp.domain.board.type.community.common.mapper.CommunityMapper;
 import com.seungwook.ktsp.domain.board.type.community.notice.entity.Notice;
@@ -33,14 +33,14 @@ public class NoticeQueryController {
 
     @Operation(summary = "모든 공지사항 조회", description = "모든 공지사항 조회, 페이징 크기 = 15")
     @GetMapping
-    public ResponseEntity<Response<Page<CommunityList>>> viewNoticeList(@RequestParam(defaultValue = "0") int page) {
+    public ResponseEntity<Response<Page<CommunityListResponse>>> viewNoticeList(@RequestParam(defaultValue = "0") int page) {
 
         // 모든 공지사항 조회
-        Page<CommunityList> allNotice = noticeService.getAllNotice(page);
+        Page<CommunityListResponse> response = CommunityMapper.toNoticeList(noticeService.getAllNotice(page));
 
-        return ResponseEntity.ok(Response.<Page<CommunityList>>builder()
+        return ResponseEntity.ok(Response.<Page<CommunityListResponse>>builder()
                 .message("공지사항 조회 성공")
-                .data(allNotice)
+                .data(response)
                 .build());
     }
 

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/repository/querydsl/NoticeQueryRepositoryImpl.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/repository/querydsl/NoticeQueryRepositoryImpl.java
@@ -29,6 +29,7 @@ public class NoticeQueryRepositoryImpl implements NoticeQueryRepository{
                         notice.id,
                         notice.title,
                         notice.hits,
+                        notice.user.name,
                         notice.createdAt)
                 )
                 .from(notice)

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeCommandService.java
@@ -35,7 +35,8 @@ public class NoticeCommandService {
         noticeRepository.save(notice);
 
         // 이미지 및 첨부파일 연결
-        boardFileBindingService.bindFilesToBoard(notice, request.getContent(), request.getAttachedFiles());
+        if (request.getAttachedFiles() != null && !request.getAttachedFiles().isEmpty())
+            boardFileBindingService.bindFilesToBoard(notice, request.getContent(), request.getAttachedFiles());
     }
 
     // 공지사항 수정
@@ -47,7 +48,8 @@ public class NoticeCommandService {
         Notice notice = findAsNotice(boardId);
 
         // 이미지 및 첨부파일 수정 반영
-        boardFileBindingService.updateBoundFiles(notice, request.getContent(), request.getAttachedFiles());
+        if (request.getAttachedFiles() != null && !request.getAttachedFiles().isEmpty())
+            boardFileBindingService.updateBoundFiles(notice, request.getContent(), request.getAttachedFiles());
 
         // 공지사항 업데이트
         notice.updateNotice(request.getTitle(), request.getContent());

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeCommandService.java
@@ -35,8 +35,8 @@ public class NoticeCommandService {
         noticeRepository.save(notice);
 
         // 이미지 및 첨부파일 연결
-        if (request.getAttachedFiles() != null && !request.getAttachedFiles().isEmpty())
-            boardFileBindingService.bindFilesToBoard(notice, request.getContent(), request.getAttachedFiles());
+        boardFileBindingService.bindFilesToBoard(notice, request.getContent(), request.getAttachedFiles());
+
     }
 
     // 공지사항 수정
@@ -48,8 +48,7 @@ public class NoticeCommandService {
         Notice notice = findAsNotice(boardId);
 
         // 이미지 및 첨부파일 수정 반영
-        if (request.getAttachedFiles() != null && !request.getAttachedFiles().isEmpty())
-            boardFileBindingService.updateBoundFiles(notice, request.getContent(), request.getAttachedFiles());
+        boardFileBindingService.updateBoundFiles(notice, request.getContent(), request.getAttachedFiles());
 
         // 공지사항 업데이트
         notice.updateNotice(request.getTitle(), request.getContent());

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeCommandService.java
@@ -2,7 +2,6 @@ package com.seungwook.ktsp.domain.board.type.community.notice.service;
 
 import com.seungwook.ktsp.domain.board.common.exception.BoardNotFoundException;
 import com.seungwook.ktsp.domain.board.common.service.BoardFileBindingService;
-import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
 import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityRegisterRequest;
 import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityUpdateRequest;
 import com.seungwook.ktsp.domain.board.type.community.notice.entity.Notice;
@@ -11,8 +10,6 @@ import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class NoticeService {
+public class NoticeCommandService {
 
     private final NoticeRepository noticeRepository;
     private final UserDomainService userDomainService;
@@ -39,24 +36,6 @@ public class NoticeService {
 
         // 이미지 및 첨부파일 연결
         boardFileBindingService.bindFilesToBoard(notice, request.getContent(), request.getAttachedFiles());
-    }
-
-    // 전체 공지사항 조회
-    public Page<CommunityList> getAllNotice(int page) {
-
-        // 최대 15개의 데이터 페이징
-        return noticeRepository.findAllNoticePage(PageRequest.of(page, 15));
-    }
-
-    // 공지사항 조회
-    @Transactional
-    public Notice getNotice(long boardId) {
-
-        // 조회수 증가
-        noticeRepository.increaseHits(boardId);
-
-        // 공지사항 조회
-        return findAsNotice(boardId);
     }
 
     // 공지사항 수정
@@ -88,7 +67,6 @@ public class NoticeService {
         // 공지사항 삭제
         noticeRepository.delete(notice);
     }
-
 
 
     // 공용 메서드

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeQueryService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeQueryService.java
@@ -1,0 +1,44 @@
+package com.seungwook.ktsp.domain.board.type.community.notice.service;
+
+import com.seungwook.ktsp.domain.board.common.exception.BoardNotFoundException;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
+import com.seungwook.ktsp.domain.board.type.community.notice.entity.Notice;
+import com.seungwook.ktsp.domain.board.type.community.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NoticeQueryService {
+
+    private final NoticeRepository noticeRepository;
+
+    // 전체 공지사항 조회
+    public Page<CommunityList> getAllNotice(int page) {
+
+        // 최대 15개의 데이터 페이징
+        return noticeRepository.findAllNoticePage(PageRequest.of(page, 15));
+    }
+
+    // 특정 공지사항 조회
+    @Transactional
+    public Notice getNotice(long boardId) {
+
+        // 조회수 증가
+        noticeRepository.increaseHits(boardId);
+
+        // 공지사항 조회
+        return findAsNotice(boardId);
+    }
+
+    // 공용 메서드
+    private Notice findAsNotice(long boardId) {
+        return noticeRepository.findNoticeById(boardId)
+                .orElseThrow(BoardNotFoundException::new);
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/notice/service/NoticeService.java
@@ -44,7 +44,7 @@ public class NoticeService {
     // 전체 공지사항 조회
     public Page<CommunityList> getAllNotice(int page) {
 
-        // 최대 10개의 데이터 페이징
+        // 최대 15개의 데이터 페이징
         return noticeRepository.findAllNoticePage(PageRequest.of(page, 15));
     }
 

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/controller/ReportCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/controller/ReportCommandController.java
@@ -12,10 +12,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "리포트")
+@Tag(name = "리포트", description = "리포트 관련 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/service/report")
+@RequestMapping("/service/board/report")
 public class ReportCommandController {
 
     private final ReportCommandService reportCommandService;

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/controller/ReportCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/controller/ReportCommandController.java
@@ -1,0 +1,55 @@
+package com.seungwook.ktsp.domain.board.type.community.report.controller;
+
+import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityRegisterRequest;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityUpdateRequest;
+import com.seungwook.ktsp.domain.board.type.community.report.service.ReportCommandService;
+import com.seungwook.ktsp.global.auth.support.AuthHandler;
+import com.seungwook.ktsp.global.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "리포트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/service/report")
+public class ReportCommandController {
+
+    private final ReportCommandService reportCommandService;
+
+    @Operation(summary = "리포트 등록")
+    @PostMapping
+    public ResponseEntity<Response<Void>> registerReport(@Valid @RequestBody CommunityRegisterRequest request) {
+
+        reportCommandService.registerReport(AuthHandler.getUserId(), request);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("리포트 등록 성공")
+                .build());
+    }
+
+    @Operation(summary = "리포트 수정")
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<Response<Void>> updateReport(@PathVariable long boardId, @Valid @RequestBody CommunityUpdateRequest request) {
+
+        reportCommandService.updateReport(boardId, request);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("리포트 수정 성공")
+                .build());
+    }
+
+    @Operation(summary = "리포트 삭제")
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<Response<Void>> deleteReport(@PathVariable long boardId) {
+
+        reportCommandService.deleteReport(boardId);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("리포트 삭제 성공")
+                .build());
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/controller/ReportQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/controller/ReportQueryController.java
@@ -75,7 +75,7 @@ public class ReportQueryController {
         CommunityResponse response = CommunityMapper.toReportResponse(writer, report, attachedFileInfos, manageable, comments);
 
         return ResponseEntity.ok(Response.<CommunityResponse>builder()
-                .message("공지사항 조회 성공")
+                .message("리포트 조회 성공")
                 .data(response)
                 .build());
     }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/controller/ReportQueryController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/controller/ReportQueryController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "리포트")
+@Tag(name = "리포트", description = "리포트 관련 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/service/board/report")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/ReportRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/ReportRepository.java
@@ -1,0 +1,13 @@
+package com.seungwook.ktsp.domain.board.type.community.report.repository;
+
+import com.seungwook.ktsp.domain.board.common.repository.hits.HitsIncrement;
+import com.seungwook.ktsp.domain.board.type.community.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReportRepository extends JpaRepository<Report, Long>, HitsIncrement {
+
+    // boardId를 바탕으로 공지사항 조회
+    Optional<Report> findReportById(Long boardId);
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/ReportRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/ReportRepository.java
@@ -2,11 +2,12 @@ package com.seungwook.ktsp.domain.board.type.community.report.repository;
 
 import com.seungwook.ktsp.domain.board.common.repository.hits.HitsIncrement;
 import com.seungwook.ktsp.domain.board.type.community.report.entity.Report;
+import com.seungwook.ktsp.domain.board.type.community.report.repository.querydsl.ReportQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ReportRepository extends JpaRepository<Report, Long>, HitsIncrement {
+public interface ReportRepository extends JpaRepository<Report, Long>, HitsIncrement, ReportQueryRepository {
 
     // boardId를 바탕으로 공지사항 조회
     Optional<Report> findReportById(Long boardId);

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/querydsl/ReportQueryRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/querydsl/ReportQueryRepository.java
@@ -8,4 +8,7 @@ public interface ReportQueryRepository {
 
     // 본인이 작성한 모든 리포트 리턴
     Page<CommunityList> getUserReports(Long userId, Pageable pageable);
+
+    // 관리자 전용 모든 리포트 리턴
+    Page<CommunityList> getAllReports(Pageable pageable);
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/querydsl/ReportQueryRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/querydsl/ReportQueryRepository.java
@@ -1,0 +1,11 @@
+package com.seungwook.ktsp.domain.board.type.community.report.repository.querydsl;
+
+import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReportQueryRepository {
+
+    // 본인이 작성한 모든 리포트 리턴
+    Page<CommunityList> getUserReports(Long userId, Pageable pageable);
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/querydsl/ReportQueryRepositoryImpl.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/querydsl/ReportQueryRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.seungwook.ktsp.domain.board.type.community.report.repository.querydsl;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.seungwook.ktsp.domain.board.type.community.report.entity.QReport.report;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportQueryRepositoryImpl implements ReportQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CommunityList> getUserReports(Long userId, Pageable pageable) {
+
+        // 본인이 작성한 Report 리스트 페이징 조회
+        List<CommunityList> contents = queryFactory
+                .select(Projections.constructor(
+                        CommunityList.class,
+                        report.id,
+                        report.title,
+                        report.hits,
+                        report.user.name,
+                        report.createdAt
+                ))
+                .from(report)
+                .where(report.user.id.eq(userId))
+                .orderBy(report.id.desc()) // 최신순 정렬
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 개수 조회
+        Long total = Optional.ofNullable(
+                queryFactory
+                        .select(report.count())
+                        .from(report)
+                        .where(report.user.id.eq(userId))
+                        .fetchOne()
+        ).orElse(0L);
+
+
+        return new PageImpl<>(contents, pageable, total);
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/querydsl/ReportQueryRepositoryImpl.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/repository/querydsl/ReportQueryRepositoryImpl.java
@@ -52,7 +52,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
         return new PageImpl<>(contents, pageable, total);
     }
 
-    // 본인이 작성한 Report 리스트 페이징 조회
+    // 모든 Report 리스트 페이징 조회 (관리자용)
     @Override
     public Page<CommunityList> getAllReports(Pageable pageable) {
         List<CommunityList> contents = queryFactory

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportCommandService.java
@@ -1,23 +1,23 @@
 package com.seungwook.ktsp.domain.board.type.community.report.service;
 
+import com.seungwook.ktsp.domain.board.common.exception.BoardNotFoundException;
 import com.seungwook.ktsp.domain.board.common.service.BoardFileBindingService;
-import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
 import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityRegisterRequest;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityUpdateRequest;
 import com.seungwook.ktsp.domain.board.type.community.report.entity.Report;
 import com.seungwook.ktsp.domain.board.type.community.report.repository.ReportRepository;
 import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ReportService {
+public class ReportCommandService {
 
     private final ReportRepository reportRepository;
     private final UserDomainService userDomainService;
@@ -30,6 +30,7 @@ public class ReportService {
         // 작성자 조회
         User user = userDomainService.getReferenceById(userId);
 
+        // 리포트 생성
         Report report = Report.createReport(user, request.getTitle(), request.getContent());
         reportRepository.save(report);
 
@@ -37,10 +38,38 @@ public class ReportService {
         boardFileBindingService.bindFilesToBoard(report, request.getContent(), request.getAttachedFiles());
     }
 
-    // 본인이 작성한 리포트 조회
-    public Page<CommunityList> getUserReports(long userId, int page) {
+    @Transactional
+    @PreAuthorize("@boardAccessHandler.check(#boardId)")
+    public void updateReport(long boardId, CommunityUpdateRequest request) {
 
-        // 최대 15개의 데이터 페이징
-        return reportRepository.getUserReports(userId, PageRequest.of(page, 15));
+        // 리포트 조회
+        Report report = findAsReport(boardId);
+
+        // 이미지 및 첨부파일 수정 반영
+        boardFileBindingService.updateBoundFiles(report, request.getContent(), request.getAttachedFiles());
+
+        // 리포트 업데이트
+        report.updateReport(report.getTitle(), request.getContent());
+    }
+
+    // 공지사항 삭제
+    @Transactional
+    @PreAuthorize("@boardAccessHandler.check(#boardId)")
+    public void deleteReport(long boardId) {
+
+        // 리포트 조회
+        Report report = findAsReport(boardId);
+
+        // 연결된 파일 삭제
+        boardFileBindingService.deleteBoundFiles(report);
+
+        // 리포트 삭제
+        reportRepository.delete(report);
+    }
+
+    // 공용 메서드
+    private Report findAsReport(long boardId) {
+        return reportRepository.findReportById(boardId)
+                .orElseThrow(BoardNotFoundException::new);
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportCommandService.java
@@ -52,7 +52,7 @@ public class ReportCommandService {
         boardFileBindingService.updateBoundFiles(report, request.getContent(), request.getAttachedFiles());
 
         // 리포트 업데이트
-        report.updateReport(report.getTitle(), request.getContent());
+        report.updateReport(request.getTitle(), request.getContent());
     }
 
     // 공지사항 삭제

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportCommandService.java
@@ -6,6 +6,7 @@ import com.seungwook.ktsp.domain.board.type.community.common.dto.request.Communi
 import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityUpdateRequest;
 import com.seungwook.ktsp.domain.board.type.community.report.entity.Report;
 import com.seungwook.ktsp.domain.board.type.community.report.repository.ReportRepository;
+import com.seungwook.ktsp.domain.comment.service.CommentCommandService;
 import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class ReportCommandService {
     private final ReportRepository reportRepository;
     private final UserDomainService userDomainService;
     private final BoardFileBindingService boardFileBindingService;
+    private final CommentCommandService commentCommandService;
 
     // 리포트 등록
     @Transactional
@@ -60,6 +62,9 @@ public class ReportCommandService {
 
         // 리포트 조회
         Report report = findAsReport(boardId);
+
+        // 댓글 삭제
+        commentCommandService.deleteAllComment(report);
 
         // 연결된 파일 삭제
         boardFileBindingService.deleteBoundFiles(report);

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportCommandService.java
@@ -35,7 +35,8 @@ public class ReportCommandService {
         reportRepository.save(report);
 
         // 이미지 및 첨부파일 연결
-        boardFileBindingService.bindFilesToBoard(report, request.getContent(), request.getAttachedFiles());
+        if (request.getAttachedFiles() != null && !request.getAttachedFiles().isEmpty())
+            boardFileBindingService.bindFilesToBoard(report, request.getContent(), request.getAttachedFiles());
     }
 
     @Transactional

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportQueryService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportQueryService.java
@@ -1,0 +1,51 @@
+package com.seungwook.ktsp.domain.board.type.community.report.service;
+
+import com.seungwook.ktsp.domain.board.common.exception.BoardNotFoundException;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
+import com.seungwook.ktsp.domain.board.type.community.report.entity.Report;
+import com.seungwook.ktsp.domain.board.type.community.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReportQueryService {
+
+    private final ReportRepository reportRepository;
+
+    // 본인이 작성한 리포트 조회
+    public Page<CommunityList> getUserReports(long userId, int page) {
+
+        // 최대 15개의 데이터 페이징
+        return reportRepository.getUserReports(userId, PageRequest.of(page, 15));
+    }
+
+    // 관리자 전용 모든 리포트 조회
+    public Page<CommunityList> getAllReports(int page) {
+
+        // 최대 15개의 데이터 페이징
+        return reportRepository.getAllReports(PageRequest.of(page, 15));
+    }
+
+    // 리포트 조회
+    @Transactional
+    @PreAuthorize("@boardAccessHandler.check(#boardId)")
+    public Report getReport(long boardId) {
+
+        reportRepository.increaseHits(boardId);
+
+        return findAsReport(boardId);
+    }
+
+    // 공용 메서드
+    private Report findAsReport(long boardId) {
+        return reportRepository.findReportById(boardId)
+                .orElseThrow(BoardNotFoundException::new);
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportService.java
@@ -1,11 +1,18 @@
 package com.seungwook.ktsp.domain.board.type.community.report.service;
 
 import com.seungwook.ktsp.domain.board.common.service.BoardFileBindingService;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.CommunityList;
+import com.seungwook.ktsp.domain.board.type.community.common.dto.request.CommunityRegisterRequest;
+import com.seungwook.ktsp.domain.board.type.community.report.entity.Report;
 import com.seungwook.ktsp.domain.board.type.community.report.repository.ReportRepository;
+import com.seungwook.ktsp.domain.user.entity.User;
 import com.seungwook.ktsp.domain.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -16,5 +23,24 @@ public class ReportService {
     private final UserDomainService userDomainService;
     private final BoardFileBindingService boardFileBindingService;
 
+    // 리포트 등록
+    @Transactional
+    public void registerReport(long userId, CommunityRegisterRequest request) {
 
+        // 작성자 조회
+        User user = userDomainService.getReferenceById(userId);
+
+        Report report = Report.createReport(user, request.getTitle(), request.getContent());
+        reportRepository.save(report);
+
+        // 이미지 및 첨부파일 연결
+        boardFileBindingService.bindFilesToBoard(report, request.getContent(), request.getAttachedFiles());
+    }
+
+    // 본인이 작성한 리포트 조회
+    public Page<CommunityList> getUserReports(long userId, int page) {
+
+        // 최대 15개의 데이터 페이징
+        return reportRepository.getUserReports(userId, PageRequest.of(page, 15));
+    }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/board/type/community/report/service/ReportService.java
@@ -1,0 +1,20 @@
+package com.seungwook.ktsp.domain.board.type.community.report.service;
+
+import com.seungwook.ktsp.domain.board.common.service.BoardFileBindingService;
+import com.seungwook.ktsp.domain.board.type.community.report.repository.ReportRepository;
+import com.seungwook.ktsp.domain.user.service.UserDomainService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final UserDomainService userDomainService;
+    private final BoardFileBindingService boardFileBindingService;
+
+
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/controller/CommentCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/controller/CommentCommandController.java
@@ -6,11 +6,14 @@ import com.seungwook.ktsp.domain.comment.dto.request.CommentUpdateRequest;
 import com.seungwook.ktsp.domain.comment.service.CommentCommandService;
 import com.seungwook.ktsp.global.auth.support.AuthHandler;
 import com.seungwook.ktsp.global.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Comment", description = "댓글 관련 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/service/comment")
@@ -18,6 +21,7 @@ public class CommentCommandController {
 
     private final CommentCommandService commentCommandService;
 
+    @Operation(summary = "댓글 등록")
     @PostMapping
     public ResponseEntity<Response<Void>> registerComment(@Valid @RequestBody CommentRequest request) {
 
@@ -28,8 +32,9 @@ public class CommentCommandController {
                 .build());
     }
 
+    @Operation(summary = "대댓글 등록")
     @PostMapping("/reply")
-    public ResponseEntity<Response<Void>> reply(@Valid @RequestBody CommentReplyRequest request) {
+    public ResponseEntity<Response<Void>> registerReply(@Valid @RequestBody CommentReplyRequest request) {
 
         commentCommandService.registerReply(AuthHandler.getUserId(), request);
 
@@ -38,6 +43,7 @@ public class CommentCommandController {
                 .build());
     }
 
+    @Operation(summary = "댓글, 대댓글 수정")
     @PatchMapping
     public ResponseEntity<Response<Void>> updateComment(@Valid @RequestBody CommentUpdateRequest request) {
 
@@ -48,6 +54,7 @@ public class CommentCommandController {
                 .build());
     }
 
+    @Operation(summary = "댓글, 대댓글 삭제")
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Response<Void>> deleteComment(@PathVariable long commentId) {
 

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/controller/CommentCommandController.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/controller/CommentCommandController.java
@@ -1,16 +1,15 @@
 package com.seungwook.ktsp.domain.comment.controller;
 
+import com.seungwook.ktsp.domain.comment.dto.request.CommentReplyRequest;
 import com.seungwook.ktsp.domain.comment.dto.request.CommentRequest;
+import com.seungwook.ktsp.domain.comment.dto.request.CommentUpdateRequest;
 import com.seungwook.ktsp.domain.comment.service.CommentCommandService;
 import com.seungwook.ktsp.global.auth.support.AuthHandler;
 import com.seungwook.ktsp.global.response.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,10 +20,41 @@ public class CommentCommandController {
 
     @PostMapping
     public ResponseEntity<Response<Void>> registerComment(@Valid @RequestBody CommentRequest request) {
+
         commentCommandService.registerComment(AuthHandler.getUserId(), request);
 
         return ResponseEntity.ok(Response.<Void>builder()
                 .message("댓글 등록 성공")
+                .build());
+    }
+
+    @PostMapping("/reply")
+    public ResponseEntity<Response<Void>> reply(@Valid @RequestBody CommentReplyRequest request) {
+
+        commentCommandService.registerReply(AuthHandler.getUserId(), request);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("대댓글 등록 성공")
+                .build());
+    }
+
+    @PatchMapping
+    public ResponseEntity<Response<Void>> updateComment(@Valid @RequestBody CommentUpdateRequest request) {
+
+        commentCommandService.updateComment(request);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("댓글 수정 성공")
+                .build());
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Response<Void>> deleteComment(@PathVariable long commentId) {
+
+        commentCommandService.deleteComment(commentId);
+
+        return ResponseEntity.ok(Response.<Void>builder()
+                .message("댓글 삭제 성공")
                 .build());
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/dto/CommentInfo.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/dto/CommentInfo.java
@@ -1,0 +1,18 @@
+package com.seungwook.ktsp.domain.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CommentInfo {
+    private final long userId;
+    private final String writer;
+    private final long commentId;
+    private final Long parentCommentId;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/dto/request/CommentReplyRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/dto/request/CommentReplyRequest.java
@@ -8,10 +8,10 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CommentRequest {
+public class CommentReplyRequest {
 
     @Positive(message = "잘못된 접근입니다.")
-    private final long boardId;
+    private final long parentCommentId;
 
     @NotBlank
     @Size(max = 255, message = "댓글은 최대 255 글자까지 입력할 수 있습니다.")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.seungwook.ktsp.domain.comment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +9,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class CommentUpdateRequest {
+
+    @Positive(message = "잘못된 접근입니다.")
+    private final long commentId;
 
     @NotBlank
     @Size(max = 255, message = "댓글은 최대 255 글자까지 입력할 수 있습니다.")

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/dto/response/CommentResponse.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/dto/response/CommentResponse.java
@@ -1,18 +1,29 @@
 package com.seungwook.ktsp.domain.comment.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
+@AllArgsConstructor
 public class CommentResponse {
+
     private final long commentId;
+
     private final Long parentCommentId;
-    private final String commentWriterName;
+
+    private final long userId;
+
+    private final String commenter;
+
     private final String content;
 
-    public CommentResponse(long commentId, Long parentCommentId, String commentWriterName, String content) {
-        this.commentId = commentId;
-        this.parentCommentId = parentCommentId;
-        this.commentWriterName = commentWriterName;
-        this.content = content;
-    }
+    @JsonFormat(pattern = "yy.MM.dd-HH:mm:ss")
+    private final LocalDateTime createdAt;
+
+    private final boolean isEdited;
+
+    private final boolean manageable;
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/entity/Comment.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/entity/Comment.java
@@ -9,6 +9,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,6 +42,10 @@ public class Comment extends BaseEntity {
     @Column(nullable = false, length = 255)
     private String comment;
 
+    // 양방향 매핑(부모댓글 삭제시 자식댓글도 자동 삭제)
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private final List<Comment> replies = new ArrayList<>();
+
     // 생성자
     private Comment(User user, Board board, String comment, Comment parent) {
         this.user = user;
@@ -55,7 +62,9 @@ public class Comment extends BaseEntity {
     // 대댓글 생성 정적 팩터리
     public static Comment createReply(User user, Comment parent, String comment) {
         if (parent.getParent() != null) throw new CommentException("대댓글의 대댓글은 허용하지 않음.");
-        return new Comment(user, parent.getBoard(), comment, parent);
+        Comment reply = new Comment(user, parent.getBoard(), comment, parent);
+        parent.replies.add(reply);
+        return reply;
     }
 
     // 댓글 수정

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/entity/Comment.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/entity/Comment.java
@@ -3,6 +3,7 @@ package com.seungwook.ktsp.domain.comment.entity;
 import com.seungwook.ktsp.domain.board.common.entity.Board;
 import com.seungwook.ktsp.domain.comment.exception.CommentException;
 import com.seungwook.ktsp.domain.user.entity.User;
+import com.seungwook.ktsp.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+public class Comment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,6 +58,7 @@ public class Comment {
         return new Comment(user, parent.getBoard(), comment, parent);
     }
 
+    // 댓글 수정
     public void updateComment(String comment) {
         this.comment = comment;
     }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/mapper/CommentMapper.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/mapper/CommentMapper.java
@@ -1,0 +1,32 @@
+package com.seungwook.ktsp.domain.comment.mapper;
+
+import com.seungwook.ktsp.domain.comment.dto.CommentInfo;
+import com.seungwook.ktsp.domain.comment.dto.response.CommentResponse;
+import com.seungwook.ktsp.global.auth.support.AuthHandler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CommentMapper {
+
+    public static List<CommentResponse> toCommentResponse(List<CommentInfo> comments) {
+        return comments.stream()
+                .map(comment -> new CommentResponse(
+                        comment.getCommentId(),
+                        comment.getParentCommentId(),
+                        comment.getUserId(),
+                        comment.getWriter(),
+                        comment.getContent(),
+                        comment.getCreatedAt(),
+                        isEdited(comment),
+                        AuthHandler.hasManagePermission(comment.getUserId())
+                )
+                )
+                .collect(Collectors.toList());
+    }
+
+    // 작성 시각과 수정 시각이 다르면 편집됨
+    private static boolean isEdited(CommentInfo comment) {
+        return !comment.getCreatedAt().isEqual(comment.getModifiedAt());
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/repository/CommentRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/repository/CommentRepository.java
@@ -1,21 +1,17 @@
 package com.seungwook.ktsp.domain.comment.repository;
 
 import com.seungwook.ktsp.domain.comment.entity.Comment;
+import com.seungwook.ktsp.domain.comment.repository.querydsl.CommentQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
-
-    // boardId를 바탕으로 전체 부모 댓글을 반환
-    @Query("SELECT c FROM Comment c WHERE c.board.id = :boardId AND c.parent IS NULL")
-    List<Comment> findParentCommentsByBoardId(Long boardId);
-
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQueryRepository {
 
     // commentId를 바탕으로 댓글 작성자의 userId를 리턴(AccessHandler 최적화)
     @Query("SELECT c.user.id FROM Comment c WHERE c.id = :commentId")
     Optional<Long> findWriterIdById(Long commentId);
+
 
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/repository/CommentRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.seungwook.ktsp.domain.comment.repository;
 
+import com.seungwook.ktsp.domain.board.common.entity.Board;
 import com.seungwook.ktsp.domain.comment.entity.Comment;
 import com.seungwook.ktsp.domain.comment.repository.querydsl.CommentQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,5 +14,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
     @Query("SELECT c.user.id FROM Comment c WHERE c.id = :commentId")
     Optional<Long> findWriterIdById(Long commentId);
 
-
+    // 특정 게시글의 모든 댓글 삭제
+    void deleteAllByBoard(Board board);
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/repository/querydsl/CommentQueryRepository.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/repository/querydsl/CommentQueryRepository.java
@@ -1,0 +1,11 @@
+package com.seungwook.ktsp.domain.comment.repository.querydsl;
+
+import com.seungwook.ktsp.domain.comment.dto.CommentInfo;
+
+import java.util.List;
+
+public interface CommentQueryRepository {
+
+    // 특정 Board에 있는 모든 Comment 반환
+    List<CommentInfo> getCommentsByBoardId(Long boardId);
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/repository/querydsl/CommentQueryRepositoryImpl.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/repository/querydsl/CommentQueryRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.seungwook.ktsp.domain.comment.repository.querydsl;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seungwook.ktsp.domain.comment.dto.CommentInfo;
+import com.seungwook.ktsp.domain.comment.entity.QComment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentQueryRepositoryImpl implements CommentQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CommentInfo> getCommentsByBoardId(Long boardId) {
+
+        QComment comment = QComment.comment1;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        CommentInfo.class,
+                        comment.user.id,
+                        comment.user.name,
+                        comment.id,
+                        comment.parent.id,
+                        comment.comment,
+                        comment.createdAt,
+                        comment.modifiedAt
+                ))
+                .from(comment)
+                .where(comment.board.id.eq(boardId))
+                .orderBy(comment.createdAt.desc(), comment.id.desc()) // 최신순
+                .fetch();
+    }
+}

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/CommentCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/CommentCommandService.java
@@ -2,6 +2,7 @@ package com.seungwook.ktsp.domain.comment.service;
 
 import com.seungwook.ktsp.domain.board.common.entity.Board;
 import com.seungwook.ktsp.domain.board.common.service.BoardDomainService;
+import com.seungwook.ktsp.domain.comment.dto.request.CommentReplyRequest;
 import com.seungwook.ktsp.domain.comment.dto.request.CommentRequest;
 import com.seungwook.ktsp.domain.comment.dto.request.CommentUpdateRequest;
 import com.seungwook.ktsp.domain.comment.entity.Comment;
@@ -24,17 +25,42 @@ public class CommentCommandService {
     // 댓글 등록
     @Transactional
     public void registerComment(long userId, CommentRequest request) {
+
+        // User 프록시
         User user = userDomainService.getReferenceById(userId);
+
+        // Board 프록시
         Board board = boardDomainService.getReferenceById(request.getBoardId());
+
+        // 댓글 생성 및 저장
         Comment comment = Comment.createComment(user, board, request.getComment());
+        commentDomainService.save(comment);
+    }
+
+    // 대댓글 등록
+    @Transactional
+    public void registerReply(long userId, CommentReplyRequest request) {
+
+        // User 프록시
+        User user = userDomainService.getReferenceById(userId);
+
+        // 부모 댓글 프록시
+        Comment parentComment = commentDomainService.getReferenceById(request.getParentCommentId());
+
+        // 댓글 생성 및 저장
+        Comment comment = Comment.createReply(user, parentComment, request.getComment());
         commentDomainService.save(comment);
     }
 
     // 댓글 수정
     @Transactional
-    @PreAuthorize("@commentAccessHandler.check(#commentId)")
-    public void updateComment(long commentId, CommentUpdateRequest request) {
-        Comment comment = commentDomainService.getReferenceById(commentId);
+    @PreAuthorize("@commentAccessHandler.check(#request.getCommentId())")
+    public void updateComment(CommentUpdateRequest request) {
+
+        // Comment 프록시
+        Comment comment = commentDomainService.getReferenceById(request.getCommentId());
+
+        // 댓글 수정
         comment.updateComment(request.getComment());
     }
 
@@ -42,7 +68,11 @@ public class CommentCommandService {
     @Transactional
     @PreAuthorize("@commentAccessHandler.check(#commentId)")
     public void deleteComment(long commentId) {
+
+        // Comment 프록시
         Comment comment = commentDomainService.getReferenceById(commentId);
+
+        // 댓글 삭제
         commentDomainService.delete(comment);
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/CommentCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/CommentCommandService.java
@@ -75,4 +75,9 @@ public class CommentCommandService {
         // 댓글 삭제
         commentDomainService.delete(comment);
     }
+
+    // 특정 게시글에 해당하는 모든 댓글 삭제
+    public void deleteAllComment(Board board) {
+        commentDomainService.deleteAllByBoard(board);
+    }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/CommentCommandService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/CommentCommandService.java
@@ -77,6 +77,7 @@ public class CommentCommandService {
     }
 
     // 특정 게시글에 해당하는 모든 댓글 삭제
+    @Transactional
     public void deleteAllComment(Board board) {
         commentDomainService.deleteAllByBoard(board);
     }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/CommentQueryService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/CommentQueryService.java
@@ -1,8 +1,14 @@
 package com.seungwook.ktsp.domain.comment.service;
 
+import com.seungwook.ktsp.domain.board.common.entity.Board;
+import com.seungwook.ktsp.domain.comment.dto.CommentInfo;
+import com.seungwook.ktsp.domain.comment.dto.response.CommentResponse;
+import com.seungwook.ktsp.domain.comment.mapper.CommentMapper;
 import com.seungwook.ktsp.domain.comment.service.domain.CommentDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -10,4 +16,9 @@ public class CommentQueryService {
 
     private final CommentDomainService commentDomainService;
 
+    public List<CommentResponse> getBoardComments(Board board) {
+        List<CommentInfo> comments = commentDomainService.getComments(board.getId());
+
+        return CommentMapper.toCommentResponse(comments);
+    }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/domain/CommentDomainService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/domain/CommentDomainService.java
@@ -1,5 +1,6 @@
 package com.seungwook.ktsp.domain.comment.service.domain;
 
+import com.seungwook.ktsp.domain.board.common.entity.Board;
 import com.seungwook.ktsp.domain.comment.dto.CommentInfo;
 import com.seungwook.ktsp.domain.comment.entity.Comment;
 import com.seungwook.ktsp.domain.comment.exception.CommentNotFoundException;
@@ -42,6 +43,11 @@ public class CommentDomainService {
     // 특정 게시글의 모든 댓글 반환
     public List<CommentInfo> getComments(long boardId) {
         return commentRepository.getCommentsByBoardId(boardId);
+    }
+
+    // 특정 게시글의 모든 댓글 삭제
+    public void deleteAllByBoard(Board board) {
+        commentRepository.deleteAllByBoard(board);
     }
 
     public Comment findById(long commentId) {

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/domain/CommentDomainService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/comment/service/domain/CommentDomainService.java
@@ -1,5 +1,6 @@
 package com.seungwook.ktsp.domain.comment.service.domain;
 
+import com.seungwook.ktsp.domain.comment.dto.CommentInfo;
 import com.seungwook.ktsp.domain.comment.entity.Comment;
 import com.seungwook.ktsp.domain.comment.exception.CommentNotFoundException;
 import com.seungwook.ktsp.domain.comment.repository.CommentRepository;
@@ -24,11 +25,6 @@ public class CommentDomainService {
         commentRepository.delete(comment);
     }
 
-    // 해당 게시글의 모든 부모 댓글 반환
-    public List<Comment> findParentComment(long boardId) {
-        return commentRepository.findParentCommentsByBoardId(boardId);
-    }
-
     // 댓글 작성자 userId 리턴
     public Long findWriterIdById(long commentId) {
         return commentRepository.findWriterIdById(commentId)
@@ -41,6 +37,11 @@ public class CommentDomainService {
             throw new CommentNotFoundException();
 
         return commentRepository.getReferenceById(commentId);
+    }
+
+    // 특정 게시글의 모든 댓글 반환
+    public List<CommentInfo> getComments(long boardId) {
+        return commentRepository.getCommentsByBoardId(boardId);
     }
 
     public Comment findById(long commentId) {

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/file/exception/FileNotFoundException.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/file/exception/FileNotFoundException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class FileNotFoundException extends BaseCustomException {
     public FileNotFoundException() {
-        super(HttpStatus.BAD_REQUEST, "파일을 찾을 수 없습니다.");
+        super(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다.");
     }
 }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/file/service/policy/CloudFileStoreService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/file/service/policy/CloudFileStoreService.java
@@ -135,7 +135,7 @@ public class CloudFileStoreService implements FileStoreService{
                     .key(key)
                     .build());
         } catch (S3Exception e) {
-            log.error("파일 다운로드 중 S3Excetpion 발생 - key: {}", key, e);
+            log.error("파일 다운로드 중 S3Exception 발생 - key: {}", key, e);
             throw new FileException("파일 다운로드에 실패했습니다.");
         }
     }

--- a/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserQueryService.java
+++ b/SpringBoot/src/main/java/com/seungwook/ktsp/domain/user/service/UserQueryService.java
@@ -1,8 +1,9 @@
 package com.seungwook.ktsp.domain.user.service;
 
+import com.seungwook.ktsp.domain.board.common.dto.response.Writer;
 import com.seungwook.ktsp.domain.user.dto.UserProfile;
-import com.seungwook.ktsp.domain.user.dto.WriterInfo;
 import com.seungwook.ktsp.domain.user.entity.User;
+import com.seungwook.ktsp.domain.user.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,7 +30,7 @@ public class UserQueryService {
 
     // 게시글 작성자 정보 조회
     @Transactional(readOnly = true)
-    public WriterInfo getWriterInfo(long userId) {
-        return userDomainService.findWriterInfoById(userId);
+    public Writer getWriter(long userId) {
+        return UserMapper.toWriter(userDomainService.findWriterInfoById(userId));
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#38 첨부파일이 없을 경우 NPE 발생
#26 게시판 댓글 기능

## 작업 내용
- 첨부파일이 없을 경우 NPE 발생
  - `BoardFileBindingService` 에서 게시글 생성 및 수정을 할때 첨부파일 UUID 리스트를 Optional로 감싸서 NPE 해결

- 게시판 댓글 기능
  - 댓글, 대댓글 생성 기능 추가
  - 댓글, 대댓글 수정 및 삭제 기능 추가
  - 게시판 삭제시 모든 댓글 삭제 기능 추가
  - 게시판 조회시 해당 게시판의 모든 댓글을 리턴하는 메서드 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 커뮤니티 신고 게시판(Report) 조회, 등록, 수정, 삭제 API 및 서비스가 추가되었습니다.
  * 댓글에 대한 답글(대댓글) 등록, 수정, 삭제 기능이 추가되었습니다.
  * 커뮤니티 게시글, 댓글, 신고 게시글에 대한 상세 및 목록 응답 DTO가 확장 및 신설되었습니다.

* **버그 수정**
  * 파일 미발견 예외 발생 시 HTTP 404(Not Found) 상태 코드가 반환되도록 수정되었습니다.
  * 일부 로그 메시지 오타가 수정되었습니다.

* **개선 및 변경**
  * 커뮤니티 게시글 등록/수정 시 첨부파일 최대 5개 제한이 적용되었습니다.
  * 공지/신고 게시판의 목록 및 상세 조회 응답이 개선되어 작성자, 날짜 포맷, 페이징 등 정보가 추가되었습니다.
  * 댓글 엔티티가 부모-자식 구조(답글)를 지원하도록 개선되었습니다.
  * 서비스 및 컨트롤러 구조가 조회/명령 책임 분리로 리팩토링되었습니다.

* **문서화**
  * Swagger(OpenAPI) 어노테이션이 신규 컨트롤러에 적용되어 API 문서가 보강되었습니다.

* **기타**
  * AWS SDK 및 Apache 클라이언트 라이브러리 버전이 최신으로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->